### PR TITLE
修正在多操作符条件（3个值模式）下不支持的Bug，添加LIKE，Not Like支持

### DIFF
--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -519,17 +519,7 @@ class QueryBuilder implements QueryBuilderInterface
     {
         foreach ($condition as $key => $value) {
             if (\is_int($key)) {
-                $items = count($value);
-                if($items == 1)
-                {
-                    $col = array_keys($value)[0];
-                    $val = $value[$col];
-                    $this->andWhere($col, $val);
-                }
-                else if($items > 2)
-                {
-                    $this->andCondition($value);
-                }
+                $this->andCondition($value);
             }
             else if (\is_array($value)) {
                 $this->whereIn($key, $value);

--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -519,7 +519,17 @@ class QueryBuilder implements QueryBuilderInterface
     {
         foreach ($condition as $key => $value) {
             if (\is_int($key)) {
-                $this->andCondition($value);
+                $items = count($value);
+                if($items == 1)
+                {
+                    $col = array_keys($value)[0];
+                    $val = $value[$col];
+                    $this->andWhere($col, $val);
+                }
+                else if($items > 2)
+                {
+                    $this->andCondition($value);
+                }
             }
             else if (\is_array($value)) {
                 $this->whereIn($key, $value);

--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -519,11 +519,14 @@ class QueryBuilder implements QueryBuilderInterface
     {
         foreach ($condition as $key => $value) {
             if (\is_int($key)) {
-                $this->andCondition($condition);
-                break;
+                $this->andCondition($value);
             }
-            $this->operatorCondition($condition);
-            break;
+            else if (\is_array($value)) {
+                $this->whereIn($key, $value);
+            }
+            else{
+                $this->andWhere($key, $value);
+            }
         }
 
         return $this;
@@ -548,7 +551,9 @@ class QueryBuilder implements QueryBuilderInterface
      */
     public function andCondition(array $condition)
     {
-        list(, $operator) = $condition;
+        $column = $condition[0];
+        $operator = $condition[1];
+        $value = $condition[2];
         $operator = strtoupper($operator);
         switch ($operator) {
             case self::OPERATOR_EQ:
@@ -557,24 +562,21 @@ class QueryBuilder implements QueryBuilderInterface
             case self::OPERATOR_LT:
             case self::OPERATOR_LTE:
             case self::OPERATOR_GTE:
-                list($column, $operator, $value) = $condition;
+            case self::LIKE:
+            case self::NOT_LIKE:
                 $this->andWhere($column, $value, $operator);
                 break;
             case self::IN:
-                list($column, $operator, $value) = $condition;
                 $this->whereIn($column, $value, $operator);
                 break;
             case self::NOT_IN:
-                list($column, $operator, $value) = $condition;
                 $this->whereNotIn($column, $value, $operator);
                 break;
             case self::BETWEEN:
-                list($column, , $min, $max) = $condition;
-                $this->whereBetween($column, $min, $max);
+                $this->whereBetween($column, $value, $condition[3]);
                 break;
             case self::NOT_BETWEEN:
-                list($column, , $min, $max) = $condition;
-                $this->whereNotBetween($column, $min, $max);
+                $this->whereNotBetween($column, $value, $condition[3]);
                 break;
         }
     }


### PR DESCRIPTION
1、$condition[] = ["col", "op", "val"] 原来不支持这种多个搜索条件，并提示【Notice: Undefined offset: 1】的Bug
2、原来不支持LIKE，NOT LIKE