### PR TITLE
修复文件日志异步写文件可能导致死循环的问题

### DIFF
--- a/src/framework/src/Log/FileHandler.php
+++ b/src/framework/src/Log/FileHandler.php
@@ -93,12 +93,7 @@ class FileHandler extends AbstractProcessingHandler
      */
     private function aysncWrite(string $logFile, string $messageText)
     {
-        while (true) {
-            $result = \Swoole\Async::writeFile($logFile, $messageText, null, FILE_APPEND);
-            if ($result == true) {
-                break;
-            }
-        }
+        \Swoole\Async::writeFile($logFile, $messageText, null, FILE_APPEND);
     }
 
     /**


### PR DESCRIPTION
在一些情况下`\Swoole\Async::writeFile()`返回false时仅仅只是warning而不是fatal
比如：
```
\swoole_async_set([
	'aio_mode'	=>	SWOOLE_AIO_LINUX,
]);
```
设置了以后，调用`\Swoole\Async::writeFile()`时用`FILE_APPEND`会提示
`PHP Warning:  Swoole\Async::writeFile(): cannot use FILE_APPEND with linux native aio. in xxx`
就会导致死循环
其它返回非fatal的情况未知，总之这边用死循环感觉是有些问题的