### PR TITLE
解决SQL拼接的错误

### DIFF
--- a/src/db/src/Driver/Mysql/MysqlConnection.php
+++ b/src/db/src/Driver/Mysql/MysqlConnection.php
@@ -239,7 +239,7 @@ class MysqlConnection extends AbstractDbConnection
             if ($value === null) {
                 $value = " null ";
             } else {
-                $value = "'{$value}'";
+                $value = "'" . addslashes($value) . "'";
             }
 
             if (\is_int($key)) {


### PR DESCRIPTION
data未转义，当传入的数据包含单引号时，拼接的SQL语法错误