### PR TITLE
修复两个导致Rpc Fallback不生效的问题

### DIFF
--- a/src/service-governance/src/Circuit/CircuitBreaker.php
+++ b/src/service-governance/src/Circuit/CircuitBreaker.php
@@ -1,5 +1,12 @@
 <?php
-
+/**
+ * This file is part of Swoft.
+ *
+ * @link     https://swoft.org
+ * @document https://doc.swoft.org
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ */
 namespace Swoft\Sg\Circuit;
 
 use Swoft\App;
@@ -13,22 +20,22 @@ class CircuitBreaker
     /**
      * 关闭状态
      */
-    const CLOSE = "close";
+    const CLOSE = 'close';
 
     /**
      * 开启状态
      */
-    const OPEN = "open";
+    const OPEN = 'open';
 
     /**
      * 半开起状态
      */
-    const HALF_OPEN_STATE = "halfOpenState";
+    const HALF_OPEN_STATE = 'halfOpenState';
 
     /**
      * 未初始化
      */
-    const PENDING = "pending";
+    const PENDING = 'pending';
 
     /**
      * @var int 错误请求计数
@@ -40,7 +47,6 @@ class CircuitBreaker
      */
     public $successCounter = 0;
 
-
     /**
      * @var int 开启状态切换到半开状态时间
      */
@@ -49,7 +55,7 @@ class CircuitBreaker
     /**
      * @var string 服务名称
      */
-    public $serviceName = "breakerService";
+    public $serviceName = 'breakerService';
 
     /**
      * @var CircuitBreakerState 熔断器状态，开启、半开、关闭
@@ -160,7 +166,7 @@ class CircuitBreaker
      */
     public function switchToCloseState()
     {
-        App::debug($this->serviceName . "服务，当前[" . $this->getCurrentState() . "]，熔断器状态切换，切换到[关闭]状态");
+        App::debug($this->serviceName . '服务，当前[' . $this->getCurrentState() . ']，熔断器状态切换，切换到[关闭]状态');
         $this->circuitState = new CloseState($this);
     }
 
@@ -169,7 +175,7 @@ class CircuitBreaker
      */
     public function switchToOpenState()
     {
-        App::debug($this->serviceName . "服务，当前[" . $this->getCurrentState() . "]，熔断器状态切换，切换到[开启]状态");
+        App::debug($this->serviceName . '服务，当前[' . $this->getCurrentState() . ']，熔断器状态切换，切换到[开启]状态');
         $this->circuitState = new OpenState($this);
     }
 
@@ -178,7 +184,7 @@ class CircuitBreaker
      */
     public function switchToHalfState()
     {
-        App::debug($this->serviceName . "服务，当前[" . $this->getCurrentState() . "]，熔断器状态切换，切换到[半开]状态");
+        App::debug($this->serviceName . '服务，当前[' . $this->getCurrentState() . ']，熔断器状态切换，切换到[半开]状态');
 
         $this->circuitState = new HalfOpenState($this);
     }
@@ -194,13 +200,13 @@ class CircuitBreaker
     public function fallback($fallback = null, array $params = [])
     {
         if ($fallback == null) {
-            App::debug($this->serviceName . "服务，当前[" . $this->getCurrentState() . "]，服务降级处理，fallback未定义");
+            App::debug($this->serviceName . '服务，当前[' . $this->getCurrentState() . ']，服务降级处理，fallback未定义');
             return null;
         }
 
         if (is_array($fallback) && count($fallback) == 2) {
             list($className, $method) = $fallback;
-            App::debug($this->serviceName . "服务，服务降级处理，执行fallback, class=" . $className . " method=" . $method);
+            App::debug($this->serviceName . '服务，服务降级处理，执行fallback, class=' . get_class($className) . ' method=' . $method);
 
             return $className->$method(...$params);
         }

--- a/src/service-governance/src/Circuit/CircuitBreaker.php
+++ b/src/service-governance/src/Circuit/CircuitBreaker.php
@@ -205,10 +205,10 @@ class CircuitBreaker
         }
 
         if (is_array($fallback) && count($fallback) == 2) {
-            list($className, $method) = $fallback;
-            App::debug($this->serviceName . '服务，服务降级处理，执行fallback, class=' . get_class($className) . ' method=' . $method);
+            list($fallbackObj, $method) = $fallback;
+            App::debug($this->serviceName . '服务，服务降级处理，执行fallback, class=' . get_class($fallbackObj) . ' method=' . $method);
 
-            return $className->$method(...$params);
+            return $fallbackObj->$method(...$params);
         }
 
         return null;

--- a/src/service-governance/src/Circuit/CloseState.php
+++ b/src/service-governance/src/Circuit/CloseState.php
@@ -40,8 +40,10 @@ class CloseState extends CircuitBreakerState
                 throw new \Exception($this->circuitBreaker->serviceName . '服务,连接建立失败(null)');
             }
 
-            if (($class instanceof Client && $class->isConnected() == false)||
-                ($class instanceof ConnectionInterface && $class->check() == false)) {
+            if (
+                ($class instanceof Client && $class->isConnected() == false) ||
+                ($class instanceof ConnectionInterface && $class->check() == false)
+            ) {
                 throw new \Exception($this->circuitBreaker->serviceName . '服务,当前连接已断开');
             }
             $data = $class->$method(...$params);

--- a/src/service-governance/src/Circuit/CloseState.php
+++ b/src/service-governance/src/Circuit/CloseState.php
@@ -1,9 +1,17 @@
 <?php
-
+/**
+ * This file is part of Swoft.
+ *
+ * @link     https://swoft.org
+ * @document https://doc.swoft.org
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ */
 namespace Swoft\Sg\Circuit;
 
 use Swoft\App;
 use Swoole\Coroutine\Client;
+use Swoft\Pool\ConnectionInterface;
 
 /**
  * 关闭状态及切换(close)
@@ -29,11 +37,12 @@ class CloseState extends CircuitBreakerState
 
         try {
             if ($class == null) {
-                throw new \Exception($this->circuitBreaker->serviceName . "服务,连接建立失败(null)");
+                throw new \Exception($this->circuitBreaker->serviceName . '服务,连接建立失败(null)');
             }
 
-            if ($class instanceof Client && $class->isConnected() == false) {
-                throw new \Exception($this->circuitBreaker->serviceName . "服务,当前连接已断开");
+            if (($class instanceof Client && $class->isConnected() == false)||
+                ($class instanceof ConnectionInterface && $class->check() == false)) {
+                throw new \Exception($this->circuitBreaker->serviceName . '服务,当前连接已断开');
             }
             $data = $class->$method(...$params);
         } catch (\Exception $e) {
@@ -41,18 +50,18 @@ class CloseState extends CircuitBreakerState
                 $this->circuitBreaker->incFailCount();
             }
 
-            App::error($this->circuitBreaker->serviceName . "服务，当前[关闭状态]，服务端调用失败，开始服务降级容错处理，error=" . $e->getMessage());
+            App::error($this->circuitBreaker->serviceName . '服务，当前[关闭状态]，服务端调用失败，开始服务降级容错处理，error=' . $e->getMessage());
             $data = $this->circuitBreaker->fallback($fallback);
         }
 
         $failCount = $this->circuitBreaker->getFailCounter();
         $switchToFailCount = $this->circuitBreaker->getSwitchToFailCount();
         if ($failCount >= $switchToFailCount && $this->circuitBreaker->isClose()) {
-            App::trace($this->circuitBreaker->serviceName . "服务，当前[关闭状态]，服务失败次数达到上限，开始切换为开启状态，failCount=" . $failCount);
+            App::trace($this->circuitBreaker->serviceName . '服务，当前[关闭状态]，服务失败次数达到上限，开始切换为开启状态，failCount=' . $failCount);
             $this->circuitBreaker->switchToOpenState();
         }
 
-        App::trace($this->circuitBreaker->serviceName . "服务，当前[关闭状态]，failCount=" . $this->circuitBreaker->getFailCounter());
+        App::trace($this->circuitBreaker->serviceName . '服务，当前[关闭状态]，failCount=' . $this->circuitBreaker->getFailCounter());
         return $data;
     }
 }

--- a/src/service-governance/src/Circuit/HalfOpenState.php
+++ b/src/service-governance/src/Circuit/HalfOpenState.php
@@ -1,9 +1,17 @@
 <?php
-
+/**
+ * This file is part of Swoft.
+ *
+ * @link     https://swoft.org
+ * @document https://doc.swoft.org
+ * @contact  group@swoft.org
+ * @license  https://github.com/swoft-cloud/swoft/blob/master/LICENSE
+ */
 namespace Swoft\Sg\Circuit;
 
 use Swoft\App;
 use Swoole\Coroutine\Client;
+use Swoft\Pool\ConnectionInterface;
 
 /**
  * 半开状态及切换(half-open)
@@ -36,20 +44,21 @@ class HalfOpenState extends CircuitBreakerState
 
         try {
             if ($class === null) {
-                throw new \Exception($this->getServiceName() . "服务, 建立连接失败(null)");
+                throw new \Exception($this->getServiceName() . '服务, 建立连接失败(null)');
             }
 
-            if ($class instanceof Client && $class->isConnected() == false) {
-                throw new \Exception($this->circuitBreaker->serviceName . "服务,当前连接已断开");
+            if (($class instanceof Client && $class->isConnected() == false)||
+                ($class instanceof ConnectionInterface && $class->check() == false)) {
+                throw new \Exception($this->circuitBreaker->serviceName . '服务,当前连接已断开');
             }
 
             $data = $class->$method(...$params);
             $this->circuitBreaker->incSuccessCount();
-            App::trace($this->getServiceName() . "服务，当前[半开状态]，尝试执行成");
+            App::trace($this->getServiceName() . '服务，当前[半开状态]，尝试执行成');
         } catch (\Exception $e) {
             $this->circuitBreaker->incFailCount();
             $data = $this->circuitBreaker->fallback($fallback);
-            App::error($this->getServiceName() . "服务，当前[半开状态]，尝试执行失败, error=" . $e->getMessage());
+            App::error($this->getServiceName() . '服务，当前[半开状态]，尝试执行失败, error=' . $e->getMessage());
         }
 
         $failCount = $this->circuitBreaker->getFailCounter();
@@ -59,18 +68,18 @@ class HalfOpenState extends CircuitBreakerState
 
         if ($failCount >= $switchToFailCount && $this->circuitBreaker->isHalfOpen()) {
             $this->circuitBreaker->switchToOpenState();
-            App::trace($this->getServiceName() . "服务，当前[半开状态]，失败次数达到上限，开始切换到开启状态");
+            App::trace($this->getServiceName() . '服务，当前[半开状态]，失败次数达到上限，开始切换到开启状态');
         }
 
         if ($successCount >= $switchToSuccessCount) {
             $this->circuitBreaker->switchToCloseState();
-            App::trace($this->getServiceName() . "服务，当前[半开状态]，成功次数达到上限，服务以及恢复，开始切换到关闭状态");
+            App::trace($this->getServiceName() . '服务，当前[半开状态]，成功次数达到上限，服务以及恢复，开始切换到关闭状态');
         }
 
         // 释放锁
         $lock->unlock();
 
-        App::trace($this->getServiceName() . "服务，当前[半开状态], failCount=" . $failCount . " successCount=" . $successCount);
+        App::trace($this->getServiceName() . '服务，当前[半开状态], failCount=' . $failCount . ' successCount=' . $successCount);
 
         return $data;
     }

--- a/src/service-governance/src/Circuit/HalfOpenState.php
+++ b/src/service-governance/src/Circuit/HalfOpenState.php
@@ -47,8 +47,10 @@ class HalfOpenState extends CircuitBreakerState
                 throw new \Exception($this->getServiceName() . '服务, 建立连接失败(null)');
             }
 
-            if (($class instanceof Client && $class->isConnected() == false)||
-                ($class instanceof ConnectionInterface && $class->check() == false)) {
+            if (
+                ($class instanceof Client && $class->isConnected() == false) ||
+                ($class instanceof ConnectionInterface && $class->check() == false)
+            ) {
                 throw new \Exception($this->circuitBreaker->serviceName . '服务,当前连接已断开');
             }
 


### PR DESCRIPTION
1."Object of class XXXXFallback_XXXX could not be converted to string"fatal error报错修复:
//Circuit/CircuitBreaker.php
根据相关代码 此处```$className``` 并非String,仅可能为Bean实例,其Fallback实现类未实现__toString()时
降级不生效并报错

2.Circuit/CloseState.php or  Circuit/HalfOpenState.php
链接判断代码有误，实际传入的参数为ConnectionInterface，导致未执行Fallback,rpc client直接返回null