### PR TITLE
Update server start info.

### DIFF
--- a/src/http-server/src/Bootstrap/Listener/MasterStartListener.php
+++ b/src/http-server/src/Bootstrap/Listener/MasterStartListener.php
@@ -6,6 +6,7 @@ use Swoft\App;
 use Swoft\Bean\Annotation\ServerListener;
 use Swoft\Bootstrap\Listeners\Interfaces\StartInterface;
 use Swoft\Bootstrap\SwooleEvent;
+use Swoft\Console\Helper\ConsoleUtil;
 use Swoole\Server;
 
 /**
@@ -26,5 +27,11 @@ class MasterStartListener implements StartInterface
         if (!App::$server->isDaemonize()) {
             \output()->writeln("You can use <info>CTRL + C</info> to stop run.\n");
         }
+
+        ConsoleUtil::log(
+            \sprintf('Bean scanning ... '),
+            [],
+            'info'
+        );
     }
 }

--- a/src/http-server/src/Bootstrap/Listener/WorkerStartListener.php
+++ b/src/http-server/src/Bootstrap/Listener/WorkerStartListener.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Swoft\Http\Server\Bootstrap\Listener;
+
+
+use Swoft\App;
+use Swoft\Bean\Annotation\ServerListener;
+use Swoft\Bootstrap\Listeners\Interfaces\WorkerStartInterface;
+use Swoft\Bootstrap\SwooleEvent;
+use Swoft\Console\Helper\ConsoleUtil;
+use Swoole\Server;
+
+/**
+ * Class WorkerStartListener
+ *
+ * @package Swoft\Http\Server\Bootstrap\Listener
+ * @ServerListener(SwooleEvent::ON_WORKER_START)
+ */
+class WorkerStartListener implements WorkerStartInterface
+{
+
+    public function onWorkerStart(Server $server, int $workerId, bool $isWorker)
+    {
+        $isWorker && ConsoleUtil::log(
+            \sprintf('Bean scan completed.'),
+            [],
+            'info',
+            [
+                'WorkerId' => App::getWorkerId()
+            ]
+        );
+    }
+}

--- a/src/http-server/src/Command/ServerCommand.php
+++ b/src/http-server/src/Command/ServerCommand.php
@@ -58,16 +58,15 @@ class ServerCommand
         $tcpHost = $tcpStatus['host'];
         $tcpPort = $tcpStatus['port'];
         $tcpType = $tcpStatus['type'];
-        $tcpEnable = $tcpEnable ? '<info>Enabled</info>' : '<warning>Disabled</warning>';
 
         // 信息面板
         $lines = [
             '                         Server Information                      ',
             '********************************************************************',
             "* HTTP | host: <note>$httpHost</note>, port: <note>$httpPort</note>, type: <note>$httpType</note>, worker: <note>$workerNum</note>, mode: <note>$httpMode</note>",
-            "* TCP  | host: <note>$tcpHost</note>, port: <note>$tcpPort</note>, type: <note>$tcpType</note>, worker: <note>$workerNum</note> ($tcpEnable)",
-            '********************************************************************',
         ];
+        $tcpEnable && $lines[] = "* TCP  | host: <note>$tcpHost</note>, port: <note>$tcpPort</note>, type: <note>$tcpType</note>, worker: <note>$workerNum</note> ($tcpEnable ? '<info>Enabled</info>' : '<warning>Disabled</warning>')";
+        $lines[] = '********************************************************************';
 
         // 启动服务器
         \output()->writeln(implode("\n", $lines));


### PR DESCRIPTION
1. 没有开启 TCP 时 Server Info 不显示 TCP 相关信息
2. 增加 `Bean scanning ...` 和 `Bean scan completed.` 相关提示语，解决因为看到 `Server has been started.` 以为服务已经启动完毕但 Worker 仍在扫描 Bean 时阻塞请求的误解