### PR TITLE
php_curl_client  验证ssh 的问题 

### DIFF
--- a/src/http-client/src/Adapter/CurlAdapter.php
+++ b/src/http-client/src/Adapter/CurlAdapter.php
@@ -48,8 +48,8 @@ class CurlAdapter implements AdapterInterface
         curl_setopt($resource, CURLINFO_HEADER_OUT, true);
         curl_setopt($resource, CURLOPT_RETURNTRANSFER, true);
         // HTTPS do not verify Certificate and HOST
-        curl_setopt($resource, CURLOPT_SSL_VERIFYPEER, true);
-        curl_setopt($resource, CURLOPT_SSL_VERIFYHOST, 2);
+        curl_setopt($resource, CURLOPT_SSL_VERIFYPEER, false);
+        curl_setopt($resource, CURLOPT_SSL_VERIFYHOST, 0);
 
         $result = curl_exec($resource);
 


### PR DESCRIPTION
默认不验证证书,验证有可能导致超时,批量请求的时候,会导致worker退出