### PR TITLE
Db::query() `IN` Supported

### DIFF
--- a/src/db/src/Driver/Mysql/MysqlConnection.php
+++ b/src/db/src/Driver/Mysql/MysqlConnection.php
@@ -238,10 +238,10 @@ class MysqlConnection extends AbstractDbConnection
         foreach ($params as $key => $value) {
             if ($value === null) {
                 $value = " null ";
-            } elseif (is_array($value)) {
-                $value = "'".implode("','", array_map('addslashes', $value))."'";
+            } elseif (\is_array($value)) {
+                $value = "'" . \implode("','", \array_map('addslashes', $value)) . "'";
             } else {
-                $value = "'" . addslashes($value) . "'";
+                $value = "'" . \addslashes($value) . "'";
             }
 
             if (\is_int($key)) {

--- a/src/db/src/Driver/Mysql/MysqlConnection.php
+++ b/src/db/src/Driver/Mysql/MysqlConnection.php
@@ -238,6 +238,8 @@ class MysqlConnection extends AbstractDbConnection
         foreach ($params as $key => $value) {
             if ($value === null) {
                 $value = " null ";
+            } elseif (is_array($value)) {
+                $value = "'".implode("','", array_map('addslashes', $value))."'";
             } else {
                 $value = "'" . addslashes($value) . "'";
             }


### PR DESCRIPTION
When I use Db::query with param value type is  an array, like:
```
$sql = 'SELECT * FROM `table` WHERE `id` IN (?) AND `type` = ?';
$param = [
    [1,2,3,4],
    1
];
Db::query($sql, $param);
// sql : SELECT * FROM `table` WHERE `id`  IN ('') AND `type` = '1'
```
so ~