### PR TITLE
[fixed]QueryBuilder condition error with IN/NOT IN

### DIFF
--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -556,12 +556,12 @@ class QueryBuilder implements QueryBuilderInterface
                 $this->andWhere($column, $value, $operator);
                 break;
             case self::IN:
-                list($column, $operator, $value) = $condition;
-                $this->whereIn($column, $value, $operator);
+                list($column, , $value) = $condition;
+                $this->whereIn($column, $value);
                 break;
             case self::NOT_IN:
-                list($column, $operator, $value) = $condition;
-                $this->whereNotIn($column, $value, $operator);
+                list($column, , $value) = $condition;
+                $this->whereNotIn($column, $value);
                 break;
             case self::BETWEEN:
                 list($column, , $min, $max) = $condition;


### PR DESCRIPTION
```
$condition = [
    ['id', 'in', [1, 2, 3, 4, 5]],
    ['type', 'in', [1, 2, 3]],
];
// Query
Query::table('user')->condition($condition)->get()->getResult();
// sql : SELECT * FROM user WHERE  `id` IN ('1', '2', '3', '4', '5')  in  `type` IN ('1', '2', '3')"
```

？？？
'5')  **in**  \`type\`