### PR TITLE
fix Redis Connection Ping Bug

### DIFF
--- a/src/redis/src/AbstractRedisConnection.php
+++ b/src/redis/src/AbstractRedisConnection.php
@@ -112,7 +112,9 @@ abstract class AbstractRedisConnection extends AbstractConnection
     public function check(): bool
     {
         try {
-            $this->connection->ping();
+            if (false === $this->connection->ping()) {
+                throw new \RuntimeException('Connection lost');
+            }
             $connected = true;
         } catch (\Throwable $throwable) {
             $connected = false;


### PR DESCRIPTION
$this->connection->ping() will return `0` when connection well, will return `false` when connection lost, probably only return a value but not throw an exception in coroutine client