### PR TITLE
修改 当通过QueryBuilder查询一条数据时，会报错的BUG

### DIFF
--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -1421,7 +1421,13 @@ class QueryBuilder implements QueryBuilderInterface
     {
         $this->addDecorator(function ($result) {
             if (isset($result[0]) && !empty($this->className)) {
-                return EntityHelper::arrayToEntity($result[0], $this->className);
+                if ($result[0] instanceof $this->className) {
+                    return $result[0];
+                }
+                if (is_array($result[0])) {
+                    return EntityHelper::arrayToEntity($result[0], $this->className);
+                }
+                throw new DbException('The result is not instanceof ' . $this->className);
             }
 
             if (isset($result[0]) && empty($this->join)) {

--- a/src/db/test/Cases/Mysql/QueryBuilderTest.php
+++ b/src/db/test/Cases/Mysql/QueryBuilderTest.php
@@ -448,4 +448,17 @@ class QueryBuilderTest extends AbstractMysqlCase
         $this->assertEquals($user['id'], $userid);
     }
 
+    /**
+     * @dataProvider mysqlProvider
+     *
+     * @param int $id
+     */
+    public function testModelQuerySelectOne(int $id)
+    {
+        $result = Query::table(User::class)->where('id', $id)->one()->getResult();
+        $this->assertEquals($id, $result['id']);
+
+        $result = User::query()->where('id', $id)->one()->getResult();
+        $this->assertEquals($id, $result->getId());
+    }
 }


### PR DESCRIPTION
当通过QueryBuilder查询一条数据时，因为在`addGetDecorator`方法中，已经把Array 修改成了Collection，所以当调用`arrayToEntity`时，会报错 `Argument 1 passed to Swoft\Db\Helper\EntityHelper::arrayToEntity() must be of the type array, object given`