### PR TITLE
修复执行php bin/swoft stop命令时master进程异常未退出的问题，以及停止失败后，pid文件被删除的问题

### DIFF
--- a/src/framework/src/Bootstrap/Server/AbstractServer.php
+++ b/src/framework/src/Bootstrap/Server/AbstractServer.php
@@ -142,12 +142,10 @@ abstract class AbstractServer implements ServerInterface
                 }
                 usleep(10000);
                 continue;
-            }else {
-                return true;
             }
+            
+            return true;
         }
-        //其实走不到这一步
-        return $result;
     }
 
     /**
@@ -161,7 +159,7 @@ abstract class AbstractServer implements ServerInterface
         $pFile = $this->serverSetting['pfile'];
 
         // Is pid file exist ?
-        if (file_exists($pFile)) {
+        if (\file_exists($pFile)) {
             // Get pid file content and parse the content
             $pidFile = file_get_contents($pFile);
             $pids = explode(',', $pidFile);

--- a/src/http-server/src/Command/ServerCommand.php
+++ b/src/http-server/src/Command/ServerCommand.php
@@ -122,7 +122,6 @@ class ServerCommand
         $serverStatus = $httpServer->getServerSetting();
         $pidFile = $serverStatus['pfile'];
 
-        @unlink($pidFile);
         \output()->writeln(sprintf('<info>Swoft %s is stopping ...</info>', input()->getScript()));
 
         $result = $httpServer->stop();
@@ -131,6 +130,8 @@ class ServerCommand
         if (!$result) {
             \output()->writeln(sprintf('<error>Swoft %s stop fail</error>', input()->getScript()), true, true);
         }
+        //删除pid文件
+        @unlink($pidFile);
 
         output()->writeln(sprintf('<success>Swoft %s stop success!</success>', input()->getScript()));
     }

--- a/src/rpc-server/src/Command/RpcCommand.php
+++ b/src/rpc-server/src/Command/RpcCommand.php
@@ -101,7 +101,6 @@ class RpcCommand
         $serverStatus = $rpcServer->getServerSetting();
         $pidFile = $serverStatus['pfile'];
 
-        @unlink($pidFile);
         \output()->writeln(sprintf('<info>Swoft %s is stopping ...</info>', input()->getFullScript()));
 
         $result = $rpcServer->stop();
@@ -110,6 +109,8 @@ class RpcCommand
         if (! $result) {
             \output()->writeln(sprintf('<error>Swoft %s stop fail</error>', input()->getFullScript()));
         }
+        //删除pid文件
+        @unlink($pidFile);
 
         \output()->writeln(sprintf('<success>Swoft %s stop success</success>', input()->getFullScript()));
     }

--- a/src/websocket-server/src/Command/WsCommand.php
+++ b/src/websocket-server/src/Command/WsCommand.php
@@ -120,7 +120,6 @@ class WsCommand
         $serverOpts = $server->getServerSetting();
         $pidFile = $serverOpts['pfile'];
 
-        @unlink($pidFile);
         \output()->writeln(sprintf('<info>Swoft %s is stopping ...</info>', input()->getScript()));
 
         $result = $server->stop();
@@ -129,6 +128,8 @@ class WsCommand
         if (!$result) {
             \output()->writeln(sprintf('<error>Swoft %s stop fail</error>', input()->getScript()), true, true);
         }
+        //删除pid文件
+        @unlink($pidFile);
 
         \output()->writeln(sprintf('<success>Swoft %s stop success!</success>', input()->getScript()));
     }


### PR DESCRIPTION
使用swoole_process::kill代替posix_kill解决master没有完全退出的问题。同时将pid文件删除放在了服务停止成功之后执行。