### PR TITLE
修改Redis poolName为protected，方便自定义RedisClient

### DIFF
--- a/src/redis/src/Redis.php
+++ b/src/redis/src/Redis.php
@@ -29,7 +29,7 @@ class Redis implements CacheInterface
     /**
      * @var string
      */
-    private $poolName = RedisPool::class;
+    protected $poolName = RedisPool::class;
 
     /**
      * Get the value related to the specified key


### PR DESCRIPTION
我想除了Swoft\Redis\Redis之外，实现另外一个Redis客户端，让他连接另外一个库。

这样就需要重新定义一个RedisPool 和 RedisPoolConfig，以及另外一个RedisClient，这里RedisClient继承与Swoft\Redis\Redis，但是poolName 是私有变量，改动后，基类里面的         $connectPool = App::getPool($this->poolName);拿到的poolName并不是RedisClient的，而是Swoft\Redis\Redis。

所以希望poolName 可以是protected的，方便自定义Redis客户端重写