### PR TITLE
feat: Disregister the service with consul when server stop

### DIFF
--- a/src/framework/src/Bootstrap/Server/ServerTrait.php
+++ b/src/framework/src/Bootstrap/Server/ServerTrait.php
@@ -56,6 +56,39 @@ trait ServerTrait
     }
 
     /**
+     * onManagerStop event callback
+     *
+     * @param Server $server
+     * @throws \InvalidArgumentException
+     */
+    public function onManagerStop(Server $server)
+    {
+        $this->fireServerEvent(SwooleEvent::ON_MANAGER_STOP, [$server]);
+    }
+
+    /**
+     * onWorkerStop event callback
+     *
+     * @param Server $server
+     * @throws \InvalidArgumentException
+     */
+    public function onWorkerStop(Server $server,int $worker_id)
+    {
+        $this->fireServerEvent(SwooleEvent::ON_WORKER_STOP, [$server,$worker_id]);
+    }
+
+    /**
+     * onShutdown event callback
+     *
+     * @param Server $server
+     * @throws \InvalidArgumentException
+     */
+    public function onShutdown(Server $server)
+    {
+        $this->fireServerEvent(SwooleEvent::ON_SHUTDOWN, [$server]);
+    }
+
+    /**
      * OnWorkerStart event callback
      *
      * @param Server $server server

--- a/src/framework/src/Bootstrap/SwooleEvent.php
+++ b/src/framework/src/Bootstrap/SwooleEvent.php
@@ -34,9 +34,24 @@ class SwooleEvent
     const ON_WORKER_START = 'workerStart';
 
     /**
+     * the event name of workerStop
+     */
+    const ON_WORKER_STOP = 'workerStop';
+
+    /**
      * the event name of managerStart
      */
     const ON_MANAGER_START = 'managerStart';
+
+    /**
+     * the event name of managerStop
+     */
+    const ON_MANAGER_STOP = 'managerStop';
+
+    /**
+     * the event name of shutDown
+     */
+    const ON_SHUTDOWN = 'shutdown';
 
     /**
      * the event name of request
@@ -88,7 +103,10 @@ class SwooleEvent
     private static $handlerFunctions = [
         self::ON_START         => 'onStart',
         self::ON_WORKER_START  => 'onWorkerStart',
+        self::ON_WORKER_STOP   => 'onWorkerStop',
         self::ON_MANAGER_START => 'onManagerStart',
+        self::ON_MANAGER_STOP  => 'onManagerStop',
+        self::ON_SHUTDOWN      => 'onShutdown',
         self::ON_REQUEST       => 'onRequest',
         self::ON_TASK          => 'onTask',
         self::ON_PIPE_MESSAGE  => 'onPipeMessage',

--- a/src/http-server/src/Http/HttpServer.php
+++ b/src/http-server/src/Http/HttpServer.php
@@ -44,6 +44,9 @@ class HttpServer extends AbstractServer
         $this->server->on(SwooleEvent::ON_MANAGER_START, [$this, 'onManagerStart']);
         $this->server->on(SwooleEvent::ON_REQUEST, [$this, 'onRequest']);
         $this->server->on(SwooleEvent::ON_PIPE_MESSAGE, [$this, 'onPipeMessage']);
+        $this->server->on(SwooleEvent::ON_WORKER_STOP, [$this, 'onWorkerStop']);
+        $this->server->on(SwooleEvent::ON_MANAGER_STOP, [$this, 'onManagerStop']);
+        $this->server->on(SwooleEvent::ON_SHUTDOWN, [$this, 'onShutdown']);
 
         // Start RPC Server
         if ((int)$this->serverSetting['tcpable'] === 1) {

--- a/src/rpc-server/src/Rpc/RpcServer.php
+++ b/src/rpc-server/src/Rpc/RpcServer.php
@@ -30,6 +30,9 @@ class RpcServer extends AbstractServer
         $this->server->on(SwooleEvent::ON_WORKER_START, [$this, 'onWorkerStart']);
         $this->server->on(SwooleEvent::ON_MANAGER_START, [$this, 'onManagerStart']);
         $this->server->on(SwooleEvent::ON_PIPE_MESSAGE, [$this, 'onPipeMessage']);
+        $this->server->on(SwooleEvent::ON_WORKER_STOP, [$this, 'onWorkerStop']);
+        $this->server->on(SwooleEvent::ON_MANAGER_STOP, [$this, 'onManagerStop']);
+        $this->server->on(SwooleEvent::ON_SHUTDOWN, [$this, 'onShutdown']);
 
         $swooleEvents = $this->getSwooleEvents();
         $this->registerSwooleEvents($this->server, $swooleEvents);

--- a/src/service-governance/src/Provider/ConsulProvider.php
+++ b/src/service-governance/src/Provider/ConsulProvider.php
@@ -258,7 +258,7 @@ class ConsulProvider implements ProviderInterface
         }
 
         $url = sprintf('%s:%d%s', $this->address, $this->port, self::DEREGISTER_PATH);
-        $this->outService([], $url.$this->registerId);
+        $this->removeService([], $url.$this->registerId);
 
         return true;
     }
@@ -307,12 +307,12 @@ class ConsulProvider implements ProviderInterface
     }
 
     /**
-     * OUT SERVICE
+     * Remove Service
      *
      * @param  array $service
      * @param string $url     consulURI
      */
-    private function outService(array $service, string $url)
+    private function removeService(array $service, string $url)
     {
         $options = [
             'json' => $service,

--- a/src/service-governance/src/Provider/ConsulProvider.php
+++ b/src/service-governance/src/Provider/ConsulProvider.php
@@ -308,7 +308,7 @@ class ConsulProvider implements ProviderInterface
     }
 
     /**
-     * CURL退出服务
+     * OUT SERVICE
      *
      * @param  array $service
      * @param string $url     consulURI

--- a/src/service-governance/src/Provider/ConsulProvider.php
+++ b/src/service-governance/src/Provider/ConsulProvider.php
@@ -25,6 +25,11 @@ class ConsulProvider implements ProviderInterface
     const DISCOVERY_PATH = '/v1/health/service/';
 
     /**
+     *  Deregister path
+     */
+    const DEREGISTER_PATH = '/v1/agent/service/deregister/';
+
+    /**
      * Specifies the address of the consul
      *
      * @Value(name="${config.provider.consul.address}", env="${CONSUL_ADDRESS}")
@@ -237,6 +242,28 @@ class ConsulProvider implements ProviderInterface
         return true;
     }
 
+
+    /**
+     * deregister service
+     *
+     * @param mixed ...$params
+     *
+     * @return bool
+     */
+    public function deregisterService(...$params)
+    {
+        $hostName = gethostname();
+        if (empty($this->registerId)) {
+            $this->registerId = sprintf('service-%s-%s', $this->registerName, $hostName);
+        }
+
+        $url = sprintf('%s:%d%s', $this->address, $this->port, self::DEREGISTER_PATH);
+        $this->outService([], $url.$this->registerId);
+
+        return true;
+    }
+
+
     /**
      * @param string $serviceName
      *
@@ -271,10 +298,32 @@ class ConsulProvider implements ProviderInterface
         $options = [
             'json' => $service,
         ];
+
         $httpClient = new Client();
+        $httpClient->setAdapter('curl'); //设置为curl调用
         $result = $httpClient->put($url, $options)->getResult();
         if(empty($result)){
             output()->writeln(sprintf('<success>RPC service register success by consul ! tcp=%s:%d</success>', $this->registerAddress, $this->registerPort));
+        }
+    }
+
+    /**
+     * CURL退出服务
+     *
+     * @param  array $service
+     * @param string $url     consulURI
+     */
+    private function outService(array $service, string $url)
+    {
+        $options = [
+            'json' => $service,
+        ];
+
+        $httpClient = new Client();
+        $httpClient->setAdapter('curl'); //设置为curl调用
+        $result = $httpClient->put($url, $options)->getResult();
+        if(empty($result)){
+            output()->writeln(sprintf('<success>RPC deregister service success by consul ! tcp=%s:%d</success>', $this->registerAddress, $this->registerPort));
         }
     }
 }

--- a/src/service-governance/src/Provider/ConsulProvider.php
+++ b/src/service-governance/src/Provider/ConsulProvider.php
@@ -251,9 +251,9 @@ class ConsulProvider implements ProviderInterface
      * @return bool
      */
     public function deregisterService(...$params)
-    {
-        $hostName = gethostname();
+    {        
         if (empty($this->registerId)) {
+            $hostName = gethostname();
             $this->registerId = sprintf('service-%s-%s', $this->registerName, $hostName);
         }
 
@@ -300,7 +300,6 @@ class ConsulProvider implements ProviderInterface
         ];
 
         $httpClient = new Client();
-        $httpClient->setAdapter('curl'); //设置为curl调用
         $result = $httpClient->put($url, $options)->getResult();
         if(empty($result)){
             output()->writeln(sprintf('<success>RPC service register success by consul ! tcp=%s:%d</success>', $this->registerAddress, $this->registerPort));
@@ -320,7 +319,6 @@ class ConsulProvider implements ProviderInterface
         ];
 
         $httpClient = new Client();
-        $httpClient->setAdapter('curl'); //设置为curl调用
         $result = $httpClient->put($url, $options)->getResult();
         if(empty($result)){
             output()->writeln(sprintf('<success>RPC deregister service success by consul ! tcp=%s:%d</success>', $this->registerAddress, $this->registerPort));

--- a/src/service-governance/src/Provider/ConsulProvider.php
+++ b/src/service-governance/src/Provider/ConsulProvider.php
@@ -259,8 +259,6 @@ class ConsulProvider implements ProviderInterface
 
         $url = sprintf('%s:%d%s', $this->address, $this->port, self::DEREGISTER_PATH);
         $this->removeService([], $url.$this->registerId);
-
-        return true;
     }
 
 

--- a/src/service-governance/src/Provider/ProviderInterface.php
+++ b/src/service-governance/src/Provider/ProviderInterface.php
@@ -21,4 +21,12 @@ interface ProviderInterface
      * @return mixed
      */
     public function registerService(...$params);
+
+
+    /**
+     * @param mixed ...$params
+     *
+     * @return mixed
+     */
+    public function deregisterService(...$params);
 }

--- a/src/websocket-server/src/WebSocketServer.php
+++ b/src/websocket-server/src/WebSocketServer.php
@@ -64,6 +64,9 @@ class WebSocketServer extends HttpServer
         $this->server->on(SwooleEvent::ON_WORKER_START, [$this, 'onWorkerStart']);
         $this->server->on(SwooleEvent::ON_MANAGER_START, [$this, 'onManagerStart']);
         $this->server->on(SwooleEvent::ON_PIPE_MESSAGE, [$this, 'onPipeMessage']);
+        $this->server->on(SwooleEvent::ON_WORKER_STOP, [$this, 'onWorkerStop']);
+        $this->server->on(SwooleEvent::ON_MANAGER_STOP, [$this, 'onManagerStop']);
+        $this->server->on(SwooleEvent::ON_SHUTDOWN, [$this, 'onShutdown']);
 
         // bind events for ws server
         $this->server->on(SwooleEvent::ON_HAND_SHAKE, [$this, 'onHandshake']);


### PR DESCRIPTION
增加 ServerTrait 回调方法 workerStop managerStop shutdown
增加 HttpServer RpcServer WebSocketServer 监听 workerStop managerStop shutdown 事件
增加 Consul 微服务注销服务的接口定义 与 方法实现
这样可以通过监听关闭事件来进行注销微服务
