### PR TITLE
修改 Redis::ZRangeByScore 与 Redis::zRevRangeByScore 入参有误的BUG

### DIFF
--- a/src/redis/src/Operator/ZSets/ZSetRangeByScore.php
+++ b/src/redis/src/Operator/ZSets/ZSetRangeByScore.php
@@ -19,18 +19,7 @@ class ZSetRangeByScore extends ZSetRange
      */
     protected function prepareOptions($options)
     {
-        $opts = array_change_key_case($options, CASE_UPPER);
-        $finalizedOpts = array();
-
-        if (isset($opts['LIMIT']) && is_array($opts['LIMIT'])) {
-            $limit = array_change_key_case($opts['LIMIT'], CASE_UPPER);
-
-            $finalizedOpts[] = 'LIMIT';
-            $finalizedOpts[] = isset($limit['OFFSET']) ? $limit['OFFSET'] : $limit[0];
-            $finalizedOpts[] = isset($limit['COUNT']) ? $limit['COUNT'] : $limit[1];
-        }
-
-        return array_merge($finalizedOpts, parent::prepareOptions($options));
+        return [$options];
     }
 
     /**
@@ -39,16 +28,8 @@ class ZSetRangeByScore extends ZSetRange
     protected function withScores()
     {
         $arguments = $this->getArguments();
-
-        for ($i = 3; $i < count($arguments); ++$i) {
-            switch (strtoupper($arguments[$i])) {
-                case 'WITHSCORES':
-                    return true;
-
-                case 'LIMIT':
-                    $i += 2;
-                    break;
-            }
+        if (isset($arguments[3]) && is_array($arguments[3]) && array_key_exists('withscores', $arguments[3])) {
+            return true;
         }
 
         return false;

--- a/src/redis/test/Cases/ZsetTest.php
+++ b/src/redis/test/Cases/ZsetTest.php
@@ -28,7 +28,7 @@ class ZsetTest extends AbstractTestCase
         $keys = $this->redis->zRange($key, 0, -1);
         $this->assertCount(5, $keys);
 
-        $data      = [
+        $data = [
             'key4',
             'key2',
             'key3',
@@ -55,6 +55,19 @@ class ZsetTest extends AbstractTestCase
 
         $rangeKeys = $this->redis->zRange($key, 1.2, 3.2, 'xxx');
         $this->assertEquals($data2, $rangeKeys);
+
+        /** @var \Redis $redis */
+        $redis = $this->redis;
+        $rangeKeys = $redis->zRangeByScore($key, 1, 2, [
+            'limit' => [1, 1]
+        ]);
+        $this->assertEquals(['key4'], $rangeKeys);
+
+        $rangeKeys = $redis->zRangeByScore($key, 1, 2, [
+            'withscores' => true,
+            'limit' => [1, 1]
+        ]);
+        $this->assertEquals(['key4' => 1.2], $rangeKeys);
     }
 
     public function testZaddByCo()

--- a/src/redis/test/Cases/ZsetTest.php
+++ b/src/redis/test/Cases/ZsetTest.php
@@ -68,6 +68,27 @@ class ZsetTest extends AbstractTestCase
             'limit' => [1, 1]
         ]);
         $this->assertEquals(['key4' => 1.2], $rangeKeys);
+
+        $rangeKeys = $redis->zRangeByScore($key, 1.2, 3.2, [
+            'withscores' => true
+        ]);
+        $this->assertEquals($data2, $rangeKeys);
+
+        $rangeKeys = $redis->zRevRangeByScore($key, 2, 1, [
+            'limit' => [0, 1]
+        ]);
+        $this->assertEquals(['key2'], $rangeKeys);
+
+        $rangeKeys = $redis->zRevRangeByScore($key, 2, 1, [
+            'limit' => [0, 1],
+            'withscores' => true
+        ]);
+        $this->assertEquals(['key2' => 1.3], $rangeKeys);
+
+        $rangeKeys = $redis->zRevRangeByScore($key, 3.2, 1.2, [
+            'withscores' => true
+        ]);
+        $this->assertEquals(['key3' => 3.2, 'key2' => 1.3, 'key4' => 1.2], $rangeKeys);
     }
 
     public function testZaddByCo()


### PR DESCRIPTION
- 修改 Redis::ZRangeByScore 与 Redis::zRevRangeByScore 入参期望为4个，实际传入6个的BUG
- 请Review一下代码，因为之前我看到处理了这里的逻辑，不太清楚为什么会有问题。