### PR TITLE
QueryBuilder根据Entity注解参数主动切换数据库

### DIFF
--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -1242,6 +1242,8 @@ class QueryBuilder implements QueryBuilderInterface
         if (!isset($entities[$tableName]['table']['name'])) {
             throw new DbException('Class is not an entity，className=' . $tableName);
         }
+        // 选择数据库
+        $this->selectInstance($entities[$tableName]['instance']);
 
         return $entities[$tableName]['table']['name'];
     }

--- a/src/db/test/Cases/Mysql/QueryBuilderTest.php
+++ b/src/db/test/Cases/Mysql/QueryBuilderTest.php
@@ -163,6 +163,8 @@ class QueryBuilderTest extends AbstractMysqlCase
             'age'         => mt_rand(1, 100),
         ];
         $userId = Query::table(User::class)->selectInstance('other')->insert($data)->getResult();
+        $data['description']='this my desc default instance';
+        $userId2 = Query::table(User::class)->insert($data)->getResult();
 
         $user2 = Query::table(User::class)->selectInstance('other')->where('id', $userId)->one()->getResult();
         $this->assertEquals($user2['description'], 'this my desc instance');
@@ -172,10 +174,9 @@ class QueryBuilderTest extends AbstractMysqlCase
         $this->assertEquals($otherUser['age'], $data['age']);
         $this->assertEquals($otherUser['id'], $userId);
         
-        $otherUser2  = Query::table(OtherUser::class)->selectInstance('other')->where('id', $userId)->one()->getResult();
-        $this->assertEquals($otherUser['age'], $otherUser2['age']);
-        $this->assertEquals($otherUser['id'], $otherUser2['id']);
-
+        $otherUser2  = Query::table(OtherUser::class)->selectInstance('default')->where('id', $userId2)->one()->getResult();
+        $this->assertEquals('this my desc default instance', $otherUser2['description']);
+        
         $user  = OtherUser::findById($userId)->getResult();
         $this->assertEquals($user->getAge(), $data['age']);
         $this->assertEquals($user->getId(), $userId);

--- a/src/db/test/Cases/Mysql/QueryBuilderTest.php
+++ b/src/db/test/Cases/Mysql/QueryBuilderTest.php
@@ -171,6 +171,10 @@ class QueryBuilderTest extends AbstractMysqlCase
         $otherUser  = Query::table(OtherUser::class)->where('id', $userId)->one()->getResult();
         $this->assertEquals($otherUser['age'], $data['age']);
         $this->assertEquals($otherUser['id'], $userId);
+        
+        $otherUser2  = Query::table(OtherUser::class)->selectInstance('other')->where('id', $userId)->one()->getResult();
+        $this->assertEquals($otherUser['age'], $otherUser2['age']);
+        $this->assertEquals($otherUser['id'], $otherUser2['id']);
 
         $user  = OtherUser::findById($userId)->getResult();
         $this->assertEquals($user->getAge(), $data['age']);

--- a/src/db/test/Cases/Mysql/QueryBuilderTest.php
+++ b/src/db/test/Cases/Mysql/QueryBuilderTest.php
@@ -162,12 +162,19 @@ class QueryBuilderTest extends AbstractMysqlCase
             'description' => 'this my desc instance',
             'age'         => mt_rand(1, 100),
         ];
-        $userid = Query::table(User::class)->selectInstance('other')->insert($data)->getResult();
+        $userId = Query::table(User::class)->selectInstance('other')->insert($data)->getResult();
 
-        $user  = OtherUser::findById($userid)->getResult();
-        $user2 = Query::table(User::class)->selectInstance('other')->where('id', $userid)->one()->getResult();
+        $user2 = Query::table(User::class)->selectInstance('other')->where('id', $userId)->one()->getResult();
         $this->assertEquals($user2['description'], 'this my desc instance');
-        $this->assertEquals($user2['id'], $userid);
+        $this->assertEquals($user2['id'], $userId);
+
+        $otherUser  = Query::table(OtherUser::class)->where('id', $userId)->one()->getResult();
+        $this->assertEquals($otherUser['age'], $data['age']);
+        $this->assertEquals($otherUser['id'], $userId);
+
+        $user  = OtherUser::findById($userId)->getResult();
+        $this->assertEquals($user->getAge(), $data['age']);
+        $this->assertEquals($user->getId(), $userId);
     }
 
     public function testSelectinstanceByCo()


### PR DESCRIPTION
Entity注释如下
```
/**
 * Model\Entity
 * @Entity(instance="other")
 * @Table(name="tableName")
 */
class Entity extends Model
{
}
```

代码调用如下
```
Query::table(Entity::class)->get()->getResult();
```

原代码方案
```
Query::table(Entity::class)->selectInstance('other')->get()->getResult();
```