### PR TITLE
Rpc Client收包失败时，抛出异常

### DIFF
--- a/src/rpc-client/src/Service.php
+++ b/src/rpc-client/src/Service.php
@@ -109,6 +109,7 @@ class Service
             $result = $packer->unpack($result);
             $data   = $packer->checkData($result);
         } catch (\Throwable $throwable) {
+            $client && $client->close();
             if (empty($fallback)) {
                 throw $throwable;
             }

--- a/src/rpc-client/src/Service/AbstractServiceConnection.php
+++ b/src/rpc-client/src/Service/AbstractServiceConnection.php
@@ -9,4 +9,12 @@ use Swoft\Pool\AbstractConnection;
  */
 abstract class AbstractServiceConnection extends AbstractConnection implements ServiceConnectInterface
 {
+    /**
+     * Close connection
+     * @return bool
+     */
+    public function close()
+    {
+        return true;
+    }
 }

--- a/src/rpc-client/src/Service/ServiceConnection.php
+++ b/src/rpc-client/src/Service/ServiceConnection.php
@@ -77,7 +77,11 @@ class ServiceConnection extends AbstractServiceConnection
      */
     public function recv(): string
     {
-        return $this->connection->recv();
+        $data = $this->connection->recv();
+        if (empty($data)) {
+            throw new RpcClientException('ServiceConnection::recv error, errCode=' . $this->connection->errCode);
+        }
+        return $data;
     }
 
     /**

--- a/src/rpc-client/src/Service/ServiceConnection.php
+++ b/src/rpc-client/src/Service/ServiceConnection.php
@@ -93,4 +93,13 @@ class ServiceConnection extends AbstractServiceConnection
     {
         return App::getAppProperties()->get('server.tcp.client', []);
     }
+
+    /**
+     * Close connection
+     * @return bool
+     */
+    public function close()
+    {
+        return $this->connection->close();
+    }
 }

--- a/src/rpc-client/test/Cases/RpcTest.php
+++ b/src/rpc-client/test/Cases/RpcTest.php
@@ -42,6 +42,7 @@ class RpcTest extends AbstractTestCase
             $id = rand(1000, 9999);
             $res = $client->get($id);
             $this->assertEquals('', $res);
+
             \co::sleep(1);
 
             go(function () {

--- a/src/rpc-client/test/Cases/RpcTest.php
+++ b/src/rpc-client/test/Cases/RpcTest.php
@@ -8,7 +8,7 @@ use SwoftTest\Rpc\Testing\Clients\DemoServiceClient;
 use SwoftTest\Rpc\Testing\Lib\DemoServiceInterface;
 use SwoftTest\Rpc\Testing\Pool\Config\DemoServicePoolConfig;
 
-class DemoTest extends AbstractTestCase
+class RpcTest extends AbstractTestCase
 {
     public function testDemo()
     {
@@ -32,6 +32,33 @@ class DemoTest extends AbstractTestCase
                 $expect .= $string;
             }
             $this->assertEquals($expect, $str);
+        });
+    }
+
+    public function testRpcServiceTimeout()
+    {
+        go(function () {
+            $client = bean(DemoServiceClient::class);
+            $id = rand(1000, 9999);
+            $res = $client->get($id);
+            $this->assertEquals('', $res);
+            \co::sleep(1);
+
+            go(function () {
+                $client = bean(DemoServiceClient::class);
+                $id = rand(1000, 9999);
+                $res = $client->get($id);
+                $this->assertEquals('', $res);
+            });
+
+            \co::sleep(1);
+
+            go(function () {
+                $client = bean(DemoServiceClient::class);
+                $id = rand(1000, 9999);
+                $res = $client->get($id);
+                $this->assertEquals('', $res);
+            });
         });
     }
 }

--- a/src/rpc-client/test/Testing/Clients/DemoServiceClient.php
+++ b/src/rpc-client/test/Testing/Clients/DemoServiceClient.php
@@ -10,6 +10,7 @@ use SwoftTest\Rpc\Testing\Lib\DemoServiceInterface;
  * @Bean
  * @method version
  * @method longMessage($string)
+ * @method get($id)
  */
 class DemoServiceClient
 {

--- a/src/rpc-client/test/Testing/Fallback/DemoServiceFallback.php
+++ b/src/rpc-client/test/Testing/Fallback/DemoServiceFallback.php
@@ -12,6 +12,7 @@ use SwoftTest\Rpc\Testing\Lib\DemoServiceInterface;
  * @Fallback("demoFallback")
  * @method ResultInterface deferVersion
  * @method ResultInterface deferLongMessage($string)
+ * @method ResultInterface deferGet($id)
  */
 class DemoServiceFallback implements DemoServiceInterface
 {
@@ -23,5 +24,10 @@ class DemoServiceFallback implements DemoServiceInterface
     public function longMessage($string)
     {
         return 'bigMessageFallBack';
+    }
+
+    public function get($id)
+    {
+        return '';
     }
 }

--- a/src/rpc-client/test/Testing/Lib/DemoServiceInterface.php
+++ b/src/rpc-client/test/Testing/Lib/DemoServiceInterface.php
@@ -8,10 +8,13 @@ use Swoft\Core\ResultInterface;
  * Interface DemoServiceInterface
  * @method ResultInterface deferVersion()
  * @method ResultInterface deferLongMessage($string)
+ * @method ResultInterface deferGet($id)
  */
 interface DemoServiceInterface
 {
     public function version();
 
     public function longMessage($string);
+
+    public function get($id);
 }

--- a/src/rpc-client/test/Testing/Pool/Config/DemoServicePoolConfig.php
+++ b/src/rpc-client/test/Testing/Pool/Config/DemoServicePoolConfig.php
@@ -17,4 +17,11 @@ class DemoServicePoolConfig extends PoolProperties
     protected $uri = [
         '127.0.0.1:8099'
     ];
+
+    /**
+     * Connection timeout
+     *
+     * @var int
+     */
+    protected $timeout = 1;
 }

--- a/src/rpc-client/test/Testing/Services/DemoService.php
+++ b/src/rpc-client/test/Testing/Services/DemoService.php
@@ -10,6 +10,7 @@ use Swoft\Core\ResultInterface;
  * @Service()
  * @method ResultInterface deferVersion()
  * @method ResultInterface deferLongMessage($string)
+ * @method ResultInterface deferGet($id)
  * @package App\Services
  */
 class DemoService implements DemoServiceInterface
@@ -26,5 +27,11 @@ class DemoService implements DemoServiceInterface
             $res .= $string;
         }
         return $res;
+    }
+
+    public function get($id)
+    {
+        sleep(2);
+        return $id;
     }
 }


### PR DESCRIPTION
- Rpc Client收包失败时，直接抛出异常，走Fallback。不然当前client会重新进入队列，被下个请求获取到，从而拿到上个请求返回的数据。