### PR TITLE
修改连接池配置的timeout字段为float

### DIFF
--- a/src/framework/src/Pool/PoolConfigInterface.php
+++ b/src/framework/src/Pool/PoolConfigInterface.php
@@ -27,9 +27,9 @@ interface PoolConfigInterface extends Arrayable
     public function getMaxWait(): int;
 
     /**
-     * @return int
+     * @return float
      */
-    public function getTimeout(): int;
+    public function getTimeout(): float;
 
     /**
      * @return array

--- a/src/framework/src/Pool/PoolProperties.php
+++ b/src/framework/src/Pool/PoolProperties.php
@@ -53,7 +53,7 @@ class PoolProperties implements PoolConfigInterface
     /**
      * Connection timeout
      *
-     * @var int
+     * @var float
      */
     protected $timeout = 3;
 
@@ -126,9 +126,9 @@ class PoolProperties implements PoolConfigInterface
     }
 
     /**
-     * @return int
+     * @return float
      */
-    public function getTimeout(): int
+    public function getTimeout(): float
     {
         return $this->timeout;
     }

--- a/src/framework/test/Cases/Pool/DemoPoolConfig.php
+++ b/src/framework/test/Cases/Pool/DemoPoolConfig.php
@@ -12,5 +12,5 @@ use Swoft\Pool\PoolProperties;
  */
 class DemoPoolConfig extends PoolProperties
 {
-
+    protected $timeout = 0.5;
 }

--- a/src/framework/test/Cases/PoolTest.php
+++ b/src/framework/test/Cases/PoolTest.php
@@ -13,6 +13,7 @@ use Swoft\App;
 use SwoftTest\Pool\ConsulEnvConfig;
 use SwoftTest\Pool\ConsulPptConfig;
 use SwoftTest\Pool\DemoPool;
+use SwoftTest\Pool\DemoPoolConfig;
 use SwoftTest\Pool\EnvAndPptFromPptPoolConfig;
 use SwoftTest\Pool\EnvAndPptPoolConfig;
 use SwoftTest\Pool\EnvPoolConfig;
@@ -169,5 +170,14 @@ class PoolTest extends AbstractTestCase
         go(function () {
             $this->testGetConnection();
         });
+    }
+
+    public function testPoolConfigTimeout()
+    {
+        $pConfig = App::getBean(EnvPoolConfig::class);
+        $this->assertEquals($pConfig->getTimeout(), 2);
+
+        $dConfig = App::getBean(DemoPoolConfig::class);
+        $this->assertEquals($dConfig->getTimeout(), 0.5);
     }
 }


### PR DESCRIPTION
修改原因
- 因为Swoole Client、Swoole Mysql等的超时时间为毫秒级，所以只能传入int(秒)有些不合理。

本次修改将会对自己写的PoolConfig可能会有影响，请检查自己的代码是否存在以下两种情况
- 自己的PoolConfig实现了PoolConfigInterface接口。
- 自己的PoolConfig继承了PoolProperties，但是重写了getTimeout()方法