### PR TITLE
修改HttpClient连接使用域名，接口调用使用path+query

### DIFF
--- a/src/http-client/src/Adapter/CoroutineAdapter.php
+++ b/src/http-client/src/Adapter/CoroutineAdapter.php
@@ -51,9 +51,9 @@ class CoroutineAdapter implements AdapterInterface
 
         $path = $request->getUri()->getPath();
         $query = $request->getUri()->getQuery();
-        if ($path == '') $path = '/';
+        if ($path === '') $path = '/';
         if ($query !== '') $path .= '?' . $query;
-        
+
         $client->setDefer();
         $client->execute($path);
 

--- a/src/http-client/src/Adapter/CoroutineAdapter.php
+++ b/src/http-client/src/Adapter/CoroutineAdapter.php
@@ -44,13 +44,16 @@ class CoroutineAdapter implements AdapterInterface
         list($host, $port) = $this->ipResolve($request, $options);
 
         $ssl = $request->getUri()->getScheme() === 'https';
+
         $client = new CoHttpClient($host, $port, $ssl);
         $this->applyOptions($client, $request, $options);
         $this->applyMethod($client, $request, $options);
 
-        $path = (string)$request->getUri()->getPath();
+        $path = $request->getUri()->getPath();
+        $query = $request->getUri()->getQuery();
         if ($path == '') $path = '/';
-
+        if ($query !== '') $path .= '?' . $query;
+        
         $client->setDefer();
         $client->execute($path);
 
@@ -111,7 +114,7 @@ class CoroutineAdapter implements AdapterInterface
     private function handleOptions(array $options): array
     {
         // Auth
-        if (! empty($options['auth']) && \is_array($options['auth'])) {
+        if (!empty($options['auth']) && \is_array($options['auth'])) {
             $value = $options['auth'];
             $type = isset($value[2]) ? strtolower($value[2]) : 'basic';
             switch ($type) {
@@ -146,7 +149,7 @@ class CoroutineAdapter implements AdapterInterface
      */
     protected function applyOptions(CoHttpClient $client, RequestInterface $request, array &$options)
     {
-        if (! empty($options['body'])) {
+        if (!empty($options['body'])) {
             $options['_headers']['Content-Type'] = 'text/plain';
         }
 

--- a/src/http-client/src/Adapter/CoroutineAdapter.php
+++ b/src/http-client/src/Adapter/CoroutineAdapter.php
@@ -47,8 +47,12 @@ class CoroutineAdapter implements AdapterInterface
         $client = new CoHttpClient($host, $port, $ssl);
         $this->applyOptions($client, $request, $options);
         $this->applyMethod($client, $request, $options);
+
+        $path = (string)$request->getUri()->getPath();
+        if ($path == '') $path = '/';
+
         $client->setDefer();
-        $client->execute((string)$request->getUri()->withFragment(''));
+        $client->execute($path);
 
         App::profileEnd($profileKey);
 
@@ -96,20 +100,8 @@ class CoroutineAdapter implements AdapterInterface
         } else {
             $port = 80;
         }
-        $ipLong = ip2long($host);
 
-        if ($ipLong !== false) {
-            return [$host, $port];
-        }
-
-        // DHS Lookup
-        $ip = Coroutine::gethostbyname($host);
-        if (! $ip) {
-            $message = sprintf('DNS lookup failure, domain = %s', $host);
-            App::error($message);
-            throw new \InvalidArgumentException($message);
-        }
-        return [$ip, $port];
+        return [$host, $port];
     }
 
     /**

--- a/src/http-client/test/Cases/AbstractTestCase.php
+++ b/src/http-client/test/Cases/AbstractTestCase.php
@@ -13,5 +13,5 @@ use PHPUnit\Framework\TestCase;
  */
 class AbstractTestCase extends TestCase
 {
-
+    protected $options = ['timeout' => 10];
 }

--- a/src/http-client/test/Cases/CoroutineClientTest.php
+++ b/src/http-client/test/Cases/CoroutineClientTest.php
@@ -340,7 +340,7 @@ class CoroutineClientTest extends AbstractTestCase
             ]);
 
             $str = $client->get('/', ['_options' => [
-                'timeout' => 2
+                'timeout' => 5
             ]])->getResponse()->getBody()->getContents();
             $this->assertNotEmpty($str);
         });

--- a/src/http-client/test/Cases/CoroutineClientTest.php
+++ b/src/http-client/test/Cases/CoroutineClientTest.php
@@ -368,7 +368,10 @@ class CoroutineClientTest extends AbstractTestCase
         });
     }
 
-    public function testBaseUri()
+    /**
+     * @test
+     */
+    public function baseUri()
     {
         go(function () {
             // 测试base_uri传入的域名带path时，会主动过滤path
@@ -388,6 +391,37 @@ class CoroutineClientTest extends AbstractTestCase
             $res = $client->get('/?id2=yyy&id3=zzz')->getResult();
             $res = JsonHelper::decode($res, true);
             $this->assertEquals('id2=yyy&id3=zzz', $res['uri']['query']);
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function queryNotInvalid()
+    {
+        go(function () {
+            $client = new Client([
+                'base_uri' => 'http://echo.swoft.org',
+                '_options' => $this->options
+            ]);
+
+            $res = $client->get('0')->getResult();
+            $this->assertEquals(['message' => 'Route not found for /0'], JsonHelper::decode($res, true));
+
+            $client = new Client([
+                'base_uri' => 'http://echo.swoft.org',
+                '_options' => $this->options
+            ]);
+
+            $res = $client->get(0)->getResult();
+            $res = JsonHelper::decode($res, true);
+            $this->assertEquals('/', $res['uri']['path']);
+
+            $res = $client->get(' ')->getResult();
+            $this->assertEquals(['message' => 'Route not found for / '], JsonHelper::decode($res, true));
+
+            $res = $client->get(123)->getResult();
+            $this->assertEquals(['message' => 'Route not found for /123'], JsonHelper::decode($res, true));
         });
     }
 }

--- a/src/http-client/test/Cases/CoroutineClientTest.php
+++ b/src/http-client/test/Cases/CoroutineClientTest.php
@@ -339,7 +339,9 @@ class CoroutineClientTest extends AbstractTestCase
                 ],
             ]);
 
-            $str = $client->get('/')->getResponse()->getBody()->getContents();
+            $str = $client->get('/', ['_options' => [
+                'timeout' => 2
+            ]])->getResponse()->getBody()->getContents();
             $this->assertNotEmpty($str);
         });
     }

--- a/src/http-client/test/Cases/CoroutineClientTest.php
+++ b/src/http-client/test/Cases/CoroutineClientTest.php
@@ -24,15 +24,18 @@ class CoroutineClientTest extends AbstractTestCase
             $client = new Client();
             $client->setAdapter('coroutine');
             $method = 'GET';
+            $options = ['timeout' => 5];
 
             // Http
             /** @var Response $response */
             $response = $client->request($method, '', [
                 'base_uri' => 'http://www.swoft.org',
+                '_options' => $options,
                 'headers' => [
                     'Accept' => 'text/html'
                 ],
             ])->getResponse();
+
             $response->assertSuccessful()->assertSee('Swoft 官网');
 
             // Https
@@ -45,6 +48,7 @@ class CoroutineClientTest extends AbstractTestCase
             /** @var Response $response */
             $response = $client->request($method, '/?a=1', [
                 'base_uri' => 'http://echo.swoft.org',
+                '_options' => $options
             ])->getResponse();
             $response->assertSuccessful();
             $this->assertJson($response->getBody()->getContents());
@@ -62,6 +66,7 @@ class CoroutineClientTest extends AbstractTestCase
         go(function () {
             $client = new Client();
             $client->setAdapter('coroutine');
+            $options = ['timeout' => 5];
 
             /**
              * Post raw body
@@ -72,6 +77,7 @@ class CoroutineClientTest extends AbstractTestCase
             $response = $client->request($method, '', [
                 'base_uri' => 'http://echo.swoft.org',
                 'body' => $body,
+                '_options' => $options
             ])->getResponse();
             $response->assertSuccessful()
                 ->assertHeader('Content-Type', 'application/json')
@@ -104,6 +110,8 @@ class CoroutineClientTest extends AbstractTestCase
         go(function () {
             $client = new Client();
             $client->setAdapter('coroutine');
+            $options = ['timeout' => 5];
+
             $body = [
                 'string' => 'value',
                 'int' => 1,
@@ -118,6 +126,7 @@ class CoroutineClientTest extends AbstractTestCase
             /** @var Response $response */
             $response = $client->request($method, '', [
                 'base_uri' => 'http://echo.swoft.org',
+                '_options' => $options,
                 'form_params' => $body,
             ])->getResponse();
             $response->assertSuccessful()
@@ -151,6 +160,8 @@ class CoroutineClientTest extends AbstractTestCase
         go(function () {
             $client = new Client();
             $client->setAdapter('coroutine');
+            $options = ['timeout' => 5];
+
             $body = [
                 'string' => 'value',
                 'int' => 1,
@@ -165,6 +176,7 @@ class CoroutineClientTest extends AbstractTestCase
             /** @var Response $response */
             $response = $client->request($method, '', [
                 'base_uri' => 'http://echo.swoft.org',
+                '_options' => $options,
                 'json' => $body,
             ])->getResponse();
             $response->assertSuccessful()
@@ -198,6 +210,8 @@ class CoroutineClientTest extends AbstractTestCase
         go(function () {
             $client = new Client();
             $client->setAdapter('coroutine');
+            $options = ['timeout' => 5];
+
             $body = [
                 'string' => 'value',
                 'int' => 1,
@@ -212,6 +226,7 @@ class CoroutineClientTest extends AbstractTestCase
             /** @var Response $response */
             $response = $client->request($method, '', [
                 'base_uri' => 'http://echo.swoft.org',
+                '_options' => $options,
                 'json' => $body,
             ])->getResponse();
             $response->assertSuccessful()
@@ -245,6 +260,8 @@ class CoroutineClientTest extends AbstractTestCase
         go(function () {
             $client = new Client();
             $client->setAdapter('coroutine');
+            $options = ['timeout' => 5];
+
             $body = [
                 'string' => 'value',
                 'int' => 1,
@@ -259,6 +276,7 @@ class CoroutineClientTest extends AbstractTestCase
             /** @var Response $response */
             $response = $client->request($method, '', [
                 'base_uri' => 'http://echo.swoft.org',
+                '_options' => $options,
                 'json' => $body,
             ])->getResponse();
             $response->assertSuccessful()
@@ -294,9 +312,11 @@ class CoroutineClientTest extends AbstractTestCase
                 'base_uri' => 'http://www.swoft.org',
             ]);
             $client->setAdapter('coroutine');
-            $request1 = $client->request('GET', '');
-            $request2 = $client->request('GET', '');
-            $request3 = $client->request('GET', '');
+            $options = ['timeout' => 5];
+
+            $request1 = $client->request('GET', '', ['_options' => $options]);
+            $request2 = $client->request('GET', '', ['_options' => $options]);
+            $request3 = $client->request('GET', '', ['_options' => $options]);
 
             /** @var Response $response1 */
             $response1 = $request1->getResponse();

--- a/src/http-client/test/Cases/CoroutineClientTest.php
+++ b/src/http-client/test/Cases/CoroutineClientTest.php
@@ -15,9 +15,6 @@ use Swoft\HttpClient\Client;
  */
 class CoroutineClientTest extends AbstractTestCase
 {
-
-
-
     /**
      * @test
      */
@@ -326,6 +323,24 @@ class CoroutineClientTest extends AbstractTestCase
             $expected = sprintf('Swoft/%s PHP/%s', App::version(), PHP_VERSION);
             $this->assertEquals($expected, $client->getDefaultUserAgent());
 
+        });
+    }
+
+    /**
+     * @test
+     */
+    public function githubApi()
+    {
+        go(function () {
+            $client = new Client([
+                'base_uri' => 'https://api.github.com',
+                'headers' => [
+                    'User-Agent' => 'Swoft Cloud'
+                ],
+            ]);
+
+            $str = $client->get('/')->getResponse()->getBody()->getContents();
+            $this->assertNotEmpty($str);
         });
     }
 }

--- a/src/http-client/test/Cases/CurlClientTest.php
+++ b/src/http-client/test/Cases/CurlClientTest.php
@@ -308,4 +308,19 @@ class CurlClientTest extends AbstractTestCase
         }
     }
 
+    /**
+     * @test
+     */
+    public function githubApi()
+    {
+        $client = new Client([
+            'base_uri' => 'https://api.github.com',
+            'headers' => [
+                'User-Agent' => 'Swoft Cloud'
+            ],
+        ]);
+
+        $str = $client->get('/')->getResponse()->getBody()->getContents();
+        $this->assertNotEmpty($str);
+    }
 }

--- a/src/http-client/test/Cases/CurlClientTest.php
+++ b/src/http-client/test/Cases/CurlClientTest.php
@@ -3,6 +3,7 @@
 namespace SwoftTest\HttpClient;
 
 use Swoft\App;
+use Swoft\Helper\JsonHelper;
 use Swoft\HttpClient\Client;
 use Swoft\Http\Message\Testing\Base\Response;
 use Swoft\HttpClient\Exception\RuntimeException;
@@ -322,5 +323,24 @@ class CurlClientTest extends AbstractTestCase
 
         $str = $client->get('/')->getResponse()->getBody()->getContents();
         $this->assertNotEmpty($str);
+    }
+
+    public function testBaseUri()
+    {
+        // 测试base_uri传入的域名带path时，会主动过滤path
+        $client = new Client([
+            'base_uri' => 'http://echo.swoft.org/test',
+        ]);
+
+        $res = $client->get('/info')->getResult();
+        $this->assertEquals(['message' => 'Route not found for /info'], JsonHelper::decode($res, true));
+
+        $client = new Client([
+            'base_uri' => 'http://echo.swoft.org?id=xxx',
+        ]);
+
+        $res = $client->get('/?id2=yyy&id3=zzz')->getResult();
+        $res = JsonHelper::decode($res, true);
+        $this->assertEquals('id2=yyy&id3=zzz', $res['uri']['query']);
     }
 }


### PR DESCRIPTION
- 修改HttpClient连接使用域名，接口调用使用path+query
- 增加对应单测
- 修改因为超时，返回500导致单测失败的BUG
- fix https://github.com/swoft-cloud/swoft/issues/301