### PR TITLE
fix a bug when warnings appear in the high version of swoole

### DIFF
--- a/src/framework/src/Testing/SwooleResponse.php
+++ b/src/framework/src/Testing/SwooleResponse.php
@@ -52,9 +52,10 @@ class SwooleResponse extends \Swoole\Http\Response
 
     /**
      * 设置HttpCode，如404, 501, 200
-     * @param $code
+     * @param int $code
+     * @param string $reason
      */
-    public function status($code)
+    public function status($code, $reason = NULL)
     {
     }
 


### PR DESCRIPTION
version:
swoole 4.1

Message:
PHP Warning: Declaration of Swoft\Testing\SwooleResponse::status($code) should be compatible with Swoole\Http\Response::status($http_code, $reason = NULL)