### PR TITLE
[fixed]can't use function in DB

### DIFF
--- a/src/db/src/Statement.php
+++ b/src/db/src/Statement.php
@@ -218,7 +218,12 @@ class Statement implements StatementInterface
         foreach ($select as $column => $alias) {
             // Filter db keyword
             if (array_key_exists($column, $fieldSelect) && trim($column) != '*' && strpos($column, '.') === false) {
-                $column = sprintf('`%s`', $column);
+                // 判断是否为函数调用
+                if (strpos($column, '(') || strpos($column, ')')) {
+                    $column = sprintf('%s', $column);
+                } else {
+                    $column = sprintf('`%s`', $column);
+                }
             }
 
             $statement .= $column;

--- a/src/db/test/Cases/Mysql/QueryBuilderTest.php
+++ b/src/db/test/Cases/Mysql/QueryBuilderTest.php
@@ -473,4 +473,33 @@ class QueryBuilderTest extends AbstractMysqlCase
         $result = User::query()->where('id', $id)->one()->getResult();
         $this->assertEquals($id, $result->getId());
     }
+    
+    /**
+     * 使用函数是否可用
+     */
+    public function testQueryWithFunc()
+    {
+        // 仅统计sex = 1 的数据
+        $result = Query::table(User::class)
+            ->where('sex', 1)
+            ->groupBy('sex')
+            ->one([
+                'sex' => 'sex',
+                'count(1)' => 'sum'
+            ])->getResult();
+        // 仅统计sex = 1 的数据
+        $count = Query::table(User::class)->where('sex', 1)->count()->getResult();
+        // 比较结果
+        $this->assertEquals($result['sum'], $count);
+    }
+
+    /**
+     * 测试协程
+     */
+    public function testQueryWithFuncByCo()
+    {
+        go(function () {
+            $this->testQueryWithFunc();
+        });
+    }
 }


### PR DESCRIPTION
修复字段不可为函数调用的问题

Example:
```
Query::table($tableName)
    ->groupBy('tagId')
    ->get([
        'tagId' => 'tagId',
        'count(1)' => 'sum'
    ])->getResult();
```

Error:
```
SELECT `tagId` AS `tagId`, `count(1)` AS `sum` FROM `tableName` GROUP BY tagId

# `count(1)` AS `sum`
```

Feature:
```
SELECT `tagId` AS `tagId`, count(1) AS `sum` FROM `tableName` GROUP BY tagId

# count(1) AS `sum`
```

