### PR TITLE
add: Added support of QueryBuilder column alias

### DIFF
--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -1432,7 +1432,7 @@ class QueryBuilder implements QueryBuilderInterface
                 throw new DbException('The result is not instanceof ' . $this->className);
             }
 
-            if (isset($result[0]) && empty($this->join)) {
+            if (isset($result[0]) && empty($this->join) && !empty($this->className)) {
                 $tableName = $this->getTableName();
 
                 return EntityHelper::formatRowByType($result[0], $tableName);
@@ -1476,7 +1476,7 @@ class QueryBuilder implements QueryBuilderInterface
                 return new Collection($entities);
             }
 
-            if (!empty($result) && empty($this->join)) {
+            if (!empty($result) && empty($this->join) && !empty($this->className)) {
                 $tableName = $this->getTableName();
                 $result    = EntityHelper::formatListByType($result, $tableName);
             }

--- a/src/db/test/Cases/Mysql/QueryBuilderTest.php
+++ b/src/db/test/Cases/Mysql/QueryBuilderTest.php
@@ -473,4 +473,74 @@ class QueryBuilderTest extends AbstractMysqlCase
         $result = User::query()->where('id', $id)->one()->getResult();
         $this->assertEquals($id, $result->getId());
     }
+    
+    /**
+     * 列别名查询
+     * @throws \Swoft\Db\Exception\MysqlException
+     */
+    public function testColumnAlias()
+    {
+        // 进行数据插入
+        $userData = [
+            'name'        => 'name:'.uniqid(),
+            'sex'         => 2,
+            'description' => 'this my desc',
+            'age'         => 99,
+        ];
+        $userId = Query::table(User::class)->insert($userData)->getResult();
+        // 查询条件
+        $where = ['id' => $userId];
+
+        // 进行查询，查询单个
+        $user = Query::table(User::class)->condition($where)
+            ->one([
+                'sex' => 'sex',
+                'name' => 'nickName'
+            ])->getResult();
+        // 比较结果, 判断是否为数组
+        $this->assertEquals(is_array($user), true);
+        // 判断是否有非属性值的key
+        $this->assertEquals($user['nickName'], $userData['name']);
+
+        // 通过Entity进行查询
+        $user = User::findOne($where)->getResult();
+        // 比较结果, 判断是否为User对象
+        $this->assertEquals($user instanceof User, true);
+        $this->assertEquals($user->getName(), $userData['name']);
+
+        // 进行查询，查询多个
+        $userList = Query::table(User::class)->condition($where)
+            ->get([
+                'sex' => 'sex',
+                'name' => 'nickName'
+            ])->getResult();
+        // array_pop
+        $user = array_pop($userList);
+        // 比较结果, 判断是否为数组
+        $this->assertEquals(is_array($user), true);
+        // 判断是否有非属性值的key
+        $this->assertEquals($user['nickName'], $userData['name']);
+
+        // 通过Entity获取列表
+        /**
+         * @var \Swoft\Db\Collection $userList
+         */
+        $userList = User::findAll($where)->getResult()->all();
+        // array_pop
+        $user = array_pop($userList);
+        // 比较结果, 判断是否为User对象
+        $this->assertEquals($user instanceof User, true);
+        $this->assertEquals($user->getName(), $userData['name']);
+    }
+
+    /**
+     * 列别名查询
+     * @throws \Swoft\Db\Exception\MysqlException
+     */
+    public function testColumnAliasByCo()
+    {
+        go(function () {
+            $this->testColumnAlias();
+        });
+    }
 }


### PR DESCRIPTION
修复无法使用数据表列字段别名问题

Example：
```
Query::table(User::class)->one([
    'sex' => 'sex',
    'name' => 'nickName'
])->getResult();

# 此处将数据表name字段，别名为nickName
```

Error Message:
```
Undefined index: nickName
 /Library/WebServer/duomai/data-server/vendor/swoft/db/src/Helper/EntityHelper.php:62
 /Library/WebServer/duomai/data-server/vendor/swoft/db/src/QueryBuilder.php:1438
 /Library/WebServer/duomai/data-server/vendor/swoft/db/src/DbDataResult.php:28
 /Library/WebServer/duomai/data-server/vendor/swoft/db/test/Cases/Mysql/QueryBuilderTest.php:526
 /Library/WebServer/duomai/data-server/vendor/phpunit/phpunit/src/TextUI/Command.php:186
 /Library/WebServer/duomai/data-server/vendor/phpunit/phpunit/src/TextUI/Command.php:116
```

主要原因为QueryBuilder潜在的逻辑BUG
导致使用时，会进行 EntityHelper::formatListByType
从而在制定列别名后，无法返回数据

且，未通过Entity进行的查询，仍然进行了EntityHelper::formatListByType
性能，以及逻辑上，存在冗余损耗

Feature:
```
Query::table(User::class)->one([
    'sex' => 'sex',
    'name' => 'nickName'
])->getResult();

# 返回 ['sex' => 2, 'nickname' => '名称' ]
```

顺手也把get，获取多条数据的相同问题也修复了
```
Query::table(User::class)->get([
    'sex' => 'sex',
    'name' => 'nickName'
])->getResult();
```