### PR TITLE
优化 中间件执行顺序

### DIFF
--- a/src/http-message/composer.json
+++ b/src/http-message/composer.json
@@ -10,10 +10,7 @@
   "description": "microservice framework base on swoole",
   "license": "Apache-2.0",
   "require": {
-    "swoft/framework": "^1.0",
-    "psr/http-message": "^1.0",
-    "psr/http-server-middleware": "^1.0",
-    "psr/http-server-handler": "^1.0"
+    "psr/http-message": "^1.0"
   },
   "autoload": {
     "classmap": [

--- a/src/http-message/composer.json
+++ b/src/http-message/composer.json
@@ -10,7 +10,10 @@
   "description": "microservice framework base on swoole",
   "license": "Apache-2.0",
   "require": {
-    "psr/http-message": "^1.0"
+    "swoft/framework": "^1.0",
+    "psr/http-message": "^1.0",
+    "psr/http-server-middleware": "^1.0",
+    "psr/http-server-handler": "^1.0"
   },
   "autoload": {
     "classmap": [
@@ -24,6 +27,9 @@
   },
   "autoload-dev": {
     "psr-4": {
+      "SwoftTest\\HttpMessage\\": "test/Cases",
+      "SwoftTest\\Testing\\": "test/Testing",
+      "Swoft\\Http\\Server\\": "../http-server/src"
     }
   },
   "repositories": {

--- a/src/http-message/phpunit.xml
+++ b/src/http-message/phpunit.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="./test/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false">
+    <testsuites>
+        <testsuite name="Tests">
+            <directory suffix="Test.php">./test/Cases</directory>
+        </testsuite>
+    </testsuites>
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">./app</directory>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/http-message/src/Base/Request.php
+++ b/src/http-message/src/Base/Request.php
@@ -237,7 +237,7 @@ class Request implements RequestInterface
         }
 
         if ($this->hasHeader('host')) {
-            $header = $this->getHeader('host');
+            $header = $this->getHeaderLine('host');
         } else {
             $header = 'Host';
             $this->headerNames['host'] = 'Host';

--- a/src/http-message/src/Bean/Collector/MiddlewareCollector.php
+++ b/src/http-message/src/Bean/Collector/MiddlewareCollector.php
@@ -2,7 +2,6 @@
 
 namespace Swoft\Http\Message\Bean\Collector;
 
-use App\Controllers\MiddlewareController;
 use Swoft\Http\Message\Bean\Annotation\Middleware;
 use Swoft\Http\Message\Bean\Annotation\Middlewares;
 use Swoft\Bean\CollectorInterface;
@@ -69,10 +68,10 @@ class MiddlewareCollector implements CollectorInterface
 
         if (! empty($methodName)) {
             $scanMiddlewares = self::$middlewares[$className]['middlewares']['actions'][$methodName] ?? [];
-            self::$middlewares[$className]['middlewares']['actions'][$methodName] = array_unique(array_merge($classMiddlewares,$scanMiddlewares));
+            self::$middlewares[$className]['middlewares']['actions'][$methodName] = array_unique(array_merge($scanMiddlewares,$classMiddlewares));
         } else {
             $scanMiddlewares = self::$middlewares[$className]['middlewares']['group'] ?? [];
-            self::$middlewares[$className]['middlewares']['group'] = array_unique(array_merge($classMiddlewares, $scanMiddlewares));
+            self::$middlewares[$className]['middlewares']['group'] = array_unique(array_merge($scanMiddlewares, $classMiddlewares));
         }
     }
 
@@ -91,10 +90,10 @@ class MiddlewareCollector implements CollectorInterface
 
         if (! empty($methodName)) {
             $scanMiddlewares = self::$middlewares[$className]['middlewares']['actions'][$methodName] ?? [];
-            self::$middlewares[$className]['middlewares']['actions'][$methodName] = array_unique(array_merge($middlewares, $scanMiddlewares));
+            self::$middlewares[$className]['middlewares']['actions'][$methodName] = array_unique(array_merge($scanMiddlewares, $middlewares));
         } else {
             $scanMiddlewares = self::$middlewares[$className]['middlewares']['group'] ?? [];
-            self::$middlewares[$className]['middlewares']['group'] = array_unique(array_merge($middlewares, $scanMiddlewares));
+            self::$middlewares[$className]['middlewares']['group'] = array_unique(array_merge($scanMiddlewares, $middlewares));
         }
     }
 }

--- a/src/http-message/test/Cases/AbstractTestCase.php
+++ b/src/http-message/test/Cases/AbstractTestCase.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace SwoftTest\HttpMessage;
+
+use PHPUnit\Framework\TestCase;
+use Swoft\Http\Message\Bean\Collector\MiddlewareCollector;
+
+/**
+ * AbstractTestCase
+ */
+abstract class AbstractTestCase extends TestCase
+{
+    public function getMiddleware($controllerClass, $action)
+    {
+        $actionMiddlewares = [];
+        $collector = MiddlewareCollector::getCollector();
+        $collectedMiddlewares = $collector[$controllerClass]['middlewares']??[];
+
+        // Get group middleware from Collector
+        if ($controllerClass) {
+            $collect = $collectedMiddlewares['group'] ?? [];
+            $collect && $actionMiddlewares = array_merge($actionMiddlewares, $collect);
+        }
+        // Get the specified action middleware from Collector
+        if ($action) {
+            $collect = $collectedMiddlewares['actions'][$action]??[];
+            $collect && $actionMiddlewares = array_merge($actionMiddlewares, $collect ?? []);
+        }
+        return $actionMiddlewares;
+    }
+}

--- a/src/http-message/test/Cases/MiddlewareTest.php
+++ b/src/http-message/test/Cases/MiddlewareTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace SwoftTest\HttpMessage;
+
+use SwoftTest\Testing\Controllers\MiddlewareController;
+
+class MiddlewareTest extends AbstractTestCase
+{
+    public function testMiddleware()
+    {
+        $collector = $this->getMiddleware(MiddlewareController::class, "index");
+
+        $this->assertEquals($collector, [
+            \SwoftTest\Middlewares\ClassFirstMiddleware::class,
+            \SwoftTest\Middlewares\ClassSecondMiddleware::class,
+            \SwoftTest\Middlewares\ClassThirdMiddleware::class,
+            \SwoftTest\Middlewares\FirstMiddleware::class,
+            \SwoftTest\Middlewares\SecondMiddleware::class,
+            \SwoftTest\Middlewares\ThirdMiddleware::class,
+            \SwoftTest\Middlewares\FourthMiddleware::class,
+        ]);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/ClassFirstMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/ClassFirstMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class ClassFirstMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/ClassSecondMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/ClassSecondMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class ClassSecondMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/ClassThirdMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/ClassThirdMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class ClassThirdMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/FirstMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/FirstMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class FirstMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/FourthMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/FourthMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class FourthMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/SecondMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/SecondMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class SecondMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Cases/Middlewares/ThirdMiddleware.php
+++ b/src/http-message/test/Cases/Middlewares/ThirdMiddleware.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace SwoftTest\Middlewares;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Swoft\Bean\Annotation\Bean;
+use Swoft\Http\Message\Middleware\MiddlewareInterface;
+
+/**
+ * @Bean()
+ * Class BeforeMiddleware
+ * @package SwoftTest\Middlewares
+ */
+class ThirdMiddleware implements MiddlewareInterface
+{
+    /**
+     * Process an incoming server request and return a response, optionally delegating
+     * response creation to a handler.
+     *
+     * @param \Psr\Http\Message\ServerRequestInterface $request
+     * @param \Psr\Http\Server\RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        return $handler->handle($request);
+    }
+}

--- a/src/http-message/test/Testing/Controllers/MiddlewareController.php
+++ b/src/http-message/test/Testing/Controllers/MiddlewareController.php
@@ -1,0 +1,37 @@
+<?php
+namespace SwoftTest\Testing\Controllers;
+
+use Swoft\Http\Message\Bean\Annotation\Middleware;
+use Swoft\Http\Message\Bean\Annotation\Middlewares;
+use Swoft\Http\Server\Bean\Annotation\Controller;
+use SwoftTest\Middlewares\ClassThirdMiddleware;
+use SwoftTest\Middlewares\ClassSecondMiddleware;
+use SwoftTest\Middlewares\ClassFirstMiddleware;
+use SwoftTest\Middlewares\FirstMiddleware;
+use SwoftTest\Middlewares\SecondMiddleware;
+use SwoftTest\Middlewares\ThirdMiddleware;
+use SwoftTest\Middlewares\FourthMiddleware;
+
+/**
+ * Class ValidatorController
+ * @Controller(prefix="/middleware")
+ * @Middleware(ClassFirstMiddleware::class)
+ * @Middlewares({
+ *     @Middleware(ClassSecondMiddleware::class),
+ *     @Middleware(ClassThirdMiddleware::class)
+ * })
+ */
+class MiddlewareController
+{
+    /**
+     * @Middleware(FirstMiddleware::class)
+     * @Middleware(SecondMiddleware::class)
+     * @Middlewares({
+     *     @Middleware(ThirdMiddleware::class),
+     *     @Middleware(FourthMiddleware::class)
+     * })
+     */
+    public function index()
+    {
+    }
+}

--- a/src/http-message/test/bootstrap.php
+++ b/src/http-message/test/bootstrap.php
@@ -1,0 +1,20 @@
+<?php
+require_once dirname(dirname(__FILE__)) . "/vendor/autoload.php";
+require_once dirname(dirname(__FILE__)) . '/test/config/define.php';
+
+Swoole\Coroutine::set(array(
+    'max_coroutine' => 40960,
+));
+
+// init
+\Swoft\Bean\BeanFactory::init();
+
+/* @var \Swoft\Bootstrap\Boots\Bootable $bootstrap*/
+$bootstrap = \Swoft\App::getBean(\Swoft\Bootstrap\Bootstrap::class);
+$bootstrap->bootstrap();
+
+\Swoft\Bean\BeanFactory::reload();
+$initApplicationContext = new \Swoft\Core\InitApplicationContext();
+$initApplicationContext->init();
+\Swoft\App::$isInTest = true;
+

--- a/src/http-message/test/config/define.php
+++ b/src/http-message/test/config/define.php
@@ -1,0 +1,27 @@
+<?php
+
+use \Swoft\App;
+
+// Constants
+!defined('DS') && define('DS', DIRECTORY_SEPARATOR);
+// 系统名称
+!defined('APP_NAME') && define('APP_NAME', 'swoft');
+// 基础根目录
+!defined('BASE_PATH') && define('BASE_PATH', dirname(__DIR__, 1));
+// cli命名空间
+!defined('COMMAND_NS') && define('COMMAND_NS', "App\Commands");
+
+// 注册别名
+$aliases = [
+    '@root'       => BASE_PATH,
+    '@app'        => '@root/app',
+    '@res'        => '@root/resources',
+    '@runtime'    => '@root/runtime',
+    '@configs'    => '@root/config',
+    '@resources'  => '@root/resources',
+    '@beans'      => '@configs/beans',
+    '@properties' => '@configs/properties',
+    '@console'    => '@beans/console.php',
+    '@commands'   => '@app/commands',
+];
+App::setAliases($aliases);

--- a/src/http-message/test/config/properties/app.php
+++ b/src/http-message/test/config/properties/app.php
@@ -1,0 +1,8 @@
+<?php
+return [
+    "version"      => '1.0',
+    'autoInitBean' => true,
+    'beanScan'     => [
+        'SwoftTest\\Testing'  => BASE_PATH . "/Testing",
+    ],
+];

--- a/src/http-message/test/config/server.php
+++ b/src/http-message/test/config/server.php
@@ -1,0 +1,37 @@
+<?php
+return [
+    'server'  => [
+        'pfile'      => env('PFILE', '/tmp/swoft.pid'),
+        'pname'      => env('PNAME', 'php-swoft'),
+        'tcpable'    => env('TCPABLE', true),
+        'cronable'   => env('CRONABLE', false),
+        'autoReload' => env('AUTO_RELOAD', true),
+    ],
+    'tcp'     => [
+        'host'               => env('TCP_HOST', '0.0.0.0'),
+        'port'               => env('TCP_PORT', 8099),
+        'model'              => env('TCP_MODEL', SWOOLE_PROCESS),
+        'type'               => env('TCP_TYPE', SWOOLE_SOCK_TCP),
+        'package_max_length' => env('TCP_PACKAGE_MAX_LENGTH', 2048),
+        'open_eof_check'     => env('TCP_OPEN_EOF_CHECK', false),
+    ],
+    'http'    => [
+        'host'  => env('HTTP_HOST', '0.0.0.0'),
+        'port'  => env('HTTP_PORT', 80),
+        'model' => env('HTTP_MODEL', SWOOLE_PROCESS),
+        'type'  => env('HTTP_TYPE', SWOOLE_SOCK_TCP),
+    ],
+    'crontab' => [
+        'task_count' => env('CRONTAB_TASK_COUNT', 1024),
+        'task_queue' => env('CRONTAB_TASK_QUEUE', 2048),
+    ],
+    'setting' => [
+        'worker_num'      => env('WORKER_NUM', 1),
+        'max_request'     => env('MAX_REQUEST', 10000),
+        'daemonize'       => env('DAEMONIZE', 0),
+        'dispatch_mode'   => env('DISPATCH_MODE', 2),
+        'log_file'        => env('LOG_FILE', '@runtime/logs/swoole.log'),
+        'task_worker_num' => env('TASK_WORKER_NUM', 1),
+        'upload_tmp_dir'  => env('UPLOAD_TMP_DIR', '@runtime/uploadfiles'),
+    ],
+];


### PR DESCRIPTION
使混用`@Middleware` 和`@Middlewares` 注解时保持顺序执行中间件