### PR TITLE
修复Number验证器最大和最小的template没有生效的问题

### DIFF
--- a/src/framework/src/Helper/ValidatorHelper.php
+++ b/src/framework/src/Helper/ValidatorHelper.php
@@ -120,15 +120,15 @@ class ValidatorHelper
 
         $value = (int)$value;
         if ($min !== null && $value < $min) {
-            $template = empty($template) ?: $template;
+            $template = empty($template) ? sprintf('Parameter %s is too small (minimum is %d)', $name, $min): $template;
 
-            return self::validateError(sprintf('Parameter %s is too small (minimum is %d)', $name, $min), $throws);
+            return self::validateError($template, $throws);
         }
 
         if ($max !== null && $value > $max) {
-            $template = empty($template) ?: $template;
+            $template = empty($template) ? sprintf('Parameter %s is too big (maximum is %d)', $name, $max) : $template;
 
-            return self::validateError(sprintf('Parameter %s is too big (maximum is %d)', $name, $max), $throws);
+            return self::validateError($template, $throws);
         }
 
         return (int)$value;

--- a/src/framework/src/Helper/ValidatorHelper.php
+++ b/src/framework/src/Helper/ValidatorHelper.php
@@ -4,11 +4,6 @@ namespace Swoft\Helper;
 
 use Swoft\Exception\ValidatorException;
 
-/**
- * Class ValidatorHelper
- *
- * @package Swoft\Helper
- */
 class ValidatorHelper
 {
     /**
@@ -120,13 +115,13 @@ class ValidatorHelper
 
         $value = (int)$value;
         if ($min !== null && $value < $min) {
-            $template = empty($template) ? sprintf('Parameter %s is too small (minimum is %d)', $name, $min): $template;
+            $template = empty($template) ? sprintf('Parameter %s is too short (minimum is %d)', $name, $min): $template;
 
             return self::validateError($template, $throws);
         }
 
         if ($max !== null && $value > $max) {
-            $template = empty($template) ? sprintf('Parameter %s is too big (maximum is %d)', $name, $max) : $template;
+            $template = empty($template) ? sprintf('Parameter %s is too large (maximum is %d)', $name, $max) : $template;
 
             return self::validateError($template, $throws);
         }
@@ -177,13 +172,13 @@ class ValidatorHelper
 
         $value = (float)$value;
         if ($min !== null && $value < $min) {
-            $template = empty($template) ? sprintf('Parameter %s is too small (minimum is %d)', $name, $min) : $template;
+            $template = empty($template) ? sprintf('Parameter %s is too short (minimum is %d)', $name, $min) : $template;
 
             return self::validateError($template, $throws);
         }
 
         if ($max !== null && $value > $max) {
-            $template = empty($template) ? sprintf('Parameter %s is too big (maximum is %d)', $name, $max) : $template;
+            $template = empty($template) ? sprintf('Parameter %s is too large (maximum is %d)', $name, $max) : $template;
 
             return self::validateError($template, $throws);
         }


### PR DESCRIPTION
当使用Number验证器时，设置了template，最大和最小的提示语并没有被替换，仍是默认的的template