### PR TITLE
fix: Fixed unit test

### DIFF
--- a/src/db/test/Cases/Mysql/BugTest.php
+++ b/src/db/test/Cases/Mysql/BugTest.php
@@ -326,13 +326,13 @@ class BugTest extends AbstractMysqlCase
          * @see https://github.com/swoft-cloud/swoft-component/pull/209
          */
         $row = Query::table(User::class)->where('id', $uid)->one()->getResult();
-        $this->assertTrue(is_int($row['age']));
-        $this->assertTrue(is_int($row['sex']));
+        $this->assertTrue(is_string($row['age']));
+        $this->assertTrue(is_string($row['sex']));
         $this->assertTrue(is_string($row['description']));
         $rows = Query::table(User::class)->where('id', $uid)->get()->getResult();
         foreach ($rows as $userRow){
-            $this->assertTrue(is_int($userRow['age']));
-            $this->assertTrue(is_int($userRow['sex']));
+            $this->assertTrue(is_string($userRow['age']));
+            $this->assertTrue(is_string($userRow['sex']));
             $this->assertTrue(is_string($userRow['description']));
         }
     }

--- a/src/db/test/Cases/Mysql/BugTest.php
+++ b/src/db/test/Cases/Mysql/BugTest.php
@@ -317,17 +317,18 @@ class BugTest extends AbstractMysqlCase
         /* @var User $user*/
         $user = User::findById($uid)->getResult();
         $userAry = $user->toArray();
-
         $this->assertTrue(is_int($userAry['age']));
         $this->assertTrue(is_int($userAry['sex']));
         $this->assertTrue(is_string($userAry['desc']));
 
+        /**
+         * 通过 QueryBuilder 执行的查询将不再格式化结果属性的数据类型
+         * @see https://github.com/swoft-cloud/swoft-component/pull/209
+         */
         $row = Query::table(User::class)->where('id', $uid)->one()->getResult();
-
         $this->assertTrue(is_int($row['age']));
         $this->assertTrue(is_int($row['sex']));
         $this->assertTrue(is_string($row['description']));
-
         $rows = Query::table(User::class)->where('id', $uid)->get()->getResult();
         foreach ($rows as $userRow){
             $this->assertTrue(is_int($userRow['age']));


### PR DESCRIPTION
Since https://github.com/swoft-cloud/swoft-component/pull/209, the result that get via QueryBuilder will not format the data type anymore.
These changes still in the discussion.