### PR TITLE
修复 zRem 前缀问题

### DIFF
--- a/src/redis/src/Operator/Processor/PrefixProcessor.php
+++ b/src/redis/src/Operator/Processor/PrefixProcessor.php
@@ -95,6 +95,7 @@ class PrefixProcessor implements ProcessorInterface
             'ZADD'             => 'static::first',
             'ZINCRBY'          => 'static::first',
             'ZREM'             => 'static::first',
+            'ZDELETE'          => 'static::first',
             'ZRANGE'           => 'static::first',
             'ZREVRANGE'        => 'static::first',
             'ZRANGEBYSCORE'    => 'static::first',


### PR DESCRIPTION
zRem 对应的 zDelete 无映射前缀方法