### PR TITLE
事务异常场景下无法在commit/rollback事务前将查询模式设为非defer

### DIFF
--- a/src/db/src/Driver/Mysql/MysqlConnection.php
+++ b/src/db/src/Driver/Mysql/MysqlConnection.php
@@ -120,12 +120,13 @@ class MysqlConnection extends AbstractDbConnection
     {
         $result = $this->connection->recv();
         $this->recv = true;
-
+           
+        $this->connection->setDefer(false);
+        
         if ($result === false) {
             throw new MysqlException('Mysql recv error，connectError=' . $this->connection->connect_error . ' error=' . $this->connection->error);
         }
-        $this->connection->setDefer(false);
-
+        
         $this->result = $result;
 
         return $result;


### PR DESCRIPTION
修复在事务存在抛出异常的场景时，无法通过 receive 方法将本数据库连接置为 非 defer 模式，故仍以 defer 模式执行后续的事务 commit/rollback sql，导致后续请求再次使用此数据库连接时会被警告：mysql client is waiting for calling recv, cannot send new sql query 的问题。