### PR TITLE
fix: 修复whereIn条件为空导致扫表

### DIFF
--- a/src/db/src/QueryBuilder.php
+++ b/src/db/src/QueryBuilder.php
@@ -637,19 +637,20 @@ class QueryBuilder implements QueryBuilderInterface
 
     /**
      * where in 语句
-     *
      * @param string $column
-     * @param array  $values
+     * @param array $values
      * @param string $connector
-     *
      * @return QueryBuilder
+     * @throws MysqlException
      */
     public function whereIn(string $column, array $values, string $connector = self::LOGICAL_AND): self
     {
-        if (!empty($values)) {
-            $this->criteria($this->where, $column, $values, self::IN, $connector);
+        if(empty($values)){
+            $row   = debug_backtrace()[0];
+            $error = $row['file'].':'.$row['line'].'行';
+            throw new MysqlException('whereIn参数不能为空!'.substr($error,strrpos($error,'/')+1));
         }
-
+        $this->criteria($this->where, $column, $values, self::IN, $connector);
         return $this;
     }
 


### PR DESCRIPTION
如果使用者没有在调用whereIn之前进行判断，直接调用whereIn 一旦传入参数为空，就会导致扫描全表；
设想whereIn的使用条件，一定是要求sql查询结果是in某个条件的，否则whereIn就可以不加；
所以此处必须判空，报错！否则查询出来的结果是无意义的
