### PR TITLE
框架拦截了favicon.ico路径，导致开发者中间件无法拦截到favicon.ico

### DIFF
--- a/src/http-server/src/Middleware/SwoftMiddleware.php
+++ b/src/http-server/src/Middleware/SwoftMiddleware.php
@@ -30,11 +30,6 @@ class SwoftMiddleware implements MiddlewareInterface
      */
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        // Fix Chrome ico request bug
-        if ($request->getUri()->getPath() === '/favicon.ico') {
-            throw new NotAcceptableException('access favicon.ico');
-        }
-
         // Parser
         /* @var \Swoft\Http\Server\Parser\RequestParserInterface $requestParser */
         $requestParser = App::getBean('requestParser');


### PR DESCRIPTION
框架拦截了favicon.ico路径，导致开发者中间件无法拦截到favicon.ico