### PR TITLE
Dev

### DIFF
--- a/src/task/src/Crontab/Crontab.php
+++ b/src/task/src/Crontab/Crontab.php
@@ -148,8 +148,10 @@ class Crontab
      */
     private function cleanRunTimeTable()
     {
+        $currentTime = time();
         foreach ($this->getRunTimeTable()->table as $key => $value) {
-            if ($value['runStatus'] === self::FINISH) {
+            //判断当前时间戳是否大于任务表中时间戳
+            if ($value['runStatus'] === self::FINISH || $value['sec'] < $currentTime) {
                 $this->getRunTimeTable()->del($key);
             }
         }

--- a/src/task/src/Crontab/Crontab.php
+++ b/src/task/src/Crontab/Crontab.php
@@ -150,7 +150,6 @@ class Crontab
     {
         $currentTime = time();
         foreach ($this->getRunTimeTable()->table as $key => $value) {
-            //判断当前时间戳是否大于任务表中时间戳
             if ($value['runStatus'] === self::FINISH || $value['sec'] < $currentTime) {
                 $this->getRunTimeTable()->del($key);
             }


### PR DESCRIPTION
修复定时任务内存溢出，原因在于某些情况00秒定时任务无法跑起来，导致在runtimetable中00秒的记录一直累计。
Fixes #535