### PR TITLE
修改了打包phar之后无法识别router，报错“Router not found”的问题。

### DIFF
--- a/src/framework/src/Bean/Container.php
+++ b/src/framework/src/Bean/Container.php
@@ -14,6 +14,7 @@ use Swoft\Bean\Resource\ServerAnnotationResource;
 use Swoft\Bean\Resource\WorkerAnnotationResource;
 use Swoft\Proxy\Handler\AopHandler;
 use Swoft\Proxy\Proxy;
+use Swoft\Helper\DirHelper;
 
 /**
  * 全局容器
@@ -424,7 +425,7 @@ class Container
         }
 
         $appDir = alias("@app");
-        $dirs   = glob($appDir . "/*");
+        $dirs = DirHelper::scan($appDir, DirHelper::SCAN_CURRENT_DIR, false);
 
         $beanNamespace = [];
         foreach ($dirs as $dir) {


### PR DESCRIPTION
php自带的glob函数无法扫描phar包中的文件夹内容，返回为空数组。
改为使用框架内DirHelper::scan扫描@app下的内容。