### PR TITLE
打包之后的phar包，加载同级目录的.env配置文件，覆盖phar包中config目录下的配置。

### DIFF
--- a/src/framework/src/Bootstrap/Boots/LoadEnv.php
+++ b/src/framework/src/Bootstrap/Boots/LoadEnv.php
@@ -18,11 +18,11 @@ class LoadEnv implements Bootable
     public function bootstrap()
     {
         $file = '.env';
-        $base_dir = boolval(\Phar::running(false)) ? dirname(\Phar::running(false)) : App::getAlias('@root');
-        $filePath = $base_dir . DS . $file;
+        $baseDir = boolval(\Phar::running(false)) ? dirname(\Phar::running(false)) : App::getAlias('@root');
+        $filePath = $baseDir . DS . $file;
 
         if (\file_exists($filePath) && \is_readable($filePath)) {
-            (new Dotenv($base_dir, $file))->load();
+            (new Dotenv($baseDir, $file))->load();
         }
     }
 }

--- a/src/framework/src/Bootstrap/Boots/LoadEnv.php
+++ b/src/framework/src/Bootstrap/Boots/LoadEnv.php
@@ -18,10 +18,11 @@ class LoadEnv implements Bootable
     public function bootstrap()
     {
         $file = '.env';
-        $filePath = App::getAlias('@root') . DS . $file;
+        $base_dir = boolval(\Phar::running(false)) ? dirname(\Phar::running(false)) : App::getAlias('@root');
+        $filePath = $base_dir . DS . $file;
 
         if (\file_exists($filePath) && \is_readable($filePath)) {
-            (new Dotenv(App::getAlias('@root'), $file))->load();
+            (new Dotenv($base_dir, $file))->load();
         }
     }
 }


### PR DESCRIPTION
现有框架中，未打包之前.env中的配置会覆盖config目录中的配置。一旦打包phar，就无法加载.env中的配置来进行调试。
修改之后，使得phar包也可以加载.env配置文件来覆盖phar包中的config目录配置。