### PR TITLE
打包phar支持exclude子目录

### DIFF
--- a/src/devtool/src/PharCompiler.php
+++ b/src/devtool/src/PharCompiler.php
@@ -577,7 +577,8 @@ EOF;
 
                 // skip exclude directories.
                 if ($file->isDir()) {
-                    return !isset($this->excludes[$name]);
+                    $excludePath = str_replace(\alias('@root/'), '', $file->getPathname());
+                    return !isset($this->excludes[$excludePath]);
                 }
 
                 if ($this->suffixes) {


### PR DESCRIPTION
$compiler->addExclude() 方法的参数，目前只支持检测排除目录名，并不支持路径。
修改后，可以支持排除子目录。
例如：
$compiler->addExclude([
     'vendor/swoft/devtool',
]);