### PR TITLE
Bug Fixed: Content-Type在包含charset时无法正确解析

### DIFF
--- a/src/http-message/src/Request.php
+++ b/src/http-message/src/Request.php
@@ -634,6 +634,9 @@ class Request extends PsrRequest implements ServerRequestInterface
     {
         $contentTypes = $this->getHeader(ContentType::KEY);
         foreach ($contentTypes as $contentType) {
+            if (($pos = strpos($contentType, ';')) !== false) {
+                $contentType = substr($contentType, 0, $pos);
+            }
             $parser = $this->parsers[$contentType] ?? null;
             if ($parser && $parser instanceof RequestParserInterface) {
                 return $parser->parse($content);

--- a/src/http-message/src/Request.php
+++ b/src/http-message/src/Request.php
@@ -637,6 +637,7 @@ class Request extends PsrRequest implements ServerRequestInterface
             if (($pos = strpos($contentType, ';')) !== false) {
                 $contentType = substr($contentType, 0, $pos);
             }
+
             $parser = $this->parsers[$contentType] ?? null;
             if ($parser && $parser instanceof RequestParserInterface) {
                 return $parser->parse($content);


### PR DESCRIPTION
当header中的Content-Type包含charset时，content-type被存储为`application/json; charset=utf-8`，这会导致body中的数据body中的数据无法正常解析。

我的请求参数

```bash
curl -X "POST" "http://127.0.0.1:18306/user/register" \
     -H 'foo: bar' \
     -H 'Content-Type: application/json; charset=utf-8' \
     -d $'{
  "name": "akaQin",
  "pwd": "abcdefg",
  "age": "18"
}'
```

我遇到的报错
```json
{
  "code": 0, 
  "error": "(TypeError) Argument 1 passed to Swoft\Validator\Validator::validate() must be of the type array, string given, called in /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/Middleware/ValidatorMiddleware.php on line 62", 
  "file": "At /Users/qinlong/hbh/swoft/vendor/swoft/validator/src/Validator.php line 53", 
  "trace": "#0 /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/Middleware/ValidatorMiddleware.php(62): Swoft\Validator\Validator->validate('{"name":"akaQin...', 'App\\Http\\Contro...', 'register', Array)
#1 /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/RequestHandler.php(75): Swoft\Http\Server\Middleware\ValidatorMiddleware->process(Object(Swoft\Http\Message\Request), Object(Swoft\Http\Server\RequestHandler))
#2 /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/Middleware/UserMiddleware.php(63): Swoft\Http\Server\RequestHandler->handle(Object(Swoft\Http\Message\Request))
#3 /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/RequestHandler.php(75): Swoft\Http\Server\Middleware%userMiddleware->process(Object(Swoft\Http\Message\Request), Object(Swoft\Http\Server\RequestHandler))
#4 /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/HttpDispatcher.php(61): Swoft\Http\Server\RequestHandler->handle(Object(Swoft\Http\Message\Request))
#5 /Users/qinlong/hbh/swoft/vendor/swoft/http-server/src/Swoole/RequestListener.php(38): Swoft\Http\Server\HttpDispatcher->dispatch(Object(Swoft\Http\Message\Request), Object(Swoft\Http\Message\Response))
#6 {main}"
}
```