### PR TITLE
remove Pidfile method default return value should be true

### DIFF
--- a/src/server/src/Helper/ServerHelper.php
+++ b/src/server/src/Helper/ServerHelper.php
@@ -134,7 +134,7 @@ class ServerHelper
             return unlink($pidFile);
         }
 
-        return false;
+        return true;
     }
 
     /**


### PR DESCRIPTION
按照该方法的定义应该是想删除pid文件，如果文件不存在，应该返回true代表目的已经达到。

另外，在上一步调用中
`if (ServerHelper::killAndWait($pid, 15, $this->pidName)) { ...`
pid文件已经被删除了。所以下面的判断
```
$rmPidFile     = ServerHelper::removePidFile(alias($this->pidFile));
$rmCommandFile = ServerHelper::removePidFile(alias($this->commandFile));
return $rmPidFile && $rmCommandFile;
```
怎样都是false，就会造成重启不成功。