### PR TITLE
fixed: swoft-cloud/swoft#556 erorr with no active transaction

### DIFF
--- a/src/db/src/Driver/Mysql/SyncMysqlConnection.php
+++ b/src/db/src/Driver/Mysql/SyncMysqlConnection.php
@@ -126,6 +126,7 @@ class SyncMysqlConnection extends AbstractDbConnection
      */
     public function reconnect()
     {
+        $this->stmt = null;
         $this->createConnection();
     }
 


### PR DESCRIPTION
@inhere 
问题编号：https://github.com/swoft-cloud/swoft/issues/556