### PR TITLE
Fix 'Task' annotation 'name' default value

### DIFF
--- a/src/task/src/Annotation/Mapping/Task.php
+++ b/src/task/src/Annotation/Mapping/Task.php
@@ -1,12 +1,9 @@
 <?php declare(strict_types=1);
 
-
 namespace Swoft\Task\Annotation\Mapping;
-
 
 use Doctrine\Common\Annotations\Annotation\Attribute;
 use Doctrine\Common\Annotations\Annotation\Attributes;
-use Doctrine\Common\Annotations\Annotation\Required;
 use Doctrine\Common\Annotations\Annotation\Target;
 
 /**
@@ -23,9 +20,10 @@ use Doctrine\Common\Annotations\Annotation\Target;
 class Task
 {
     /**
-     * @var string
+     * The task name.
+     * If it is empty, it will be replaced with the class name.
      *
-     * @Required()
+     * @var string
      */
     private $name = '';
 

--- a/src/task/src/Annotation/Mapping/Task.php
+++ b/src/task/src/Annotation/Mapping/Task.php
@@ -27,7 +27,7 @@ class Task
      *
      * @Required()
      */
-    private $name;
+    private $name = '';
 
     /**
      * Task constructor.

--- a/src/task/src/Router/RouteRegister.php
+++ b/src/task/src/Router/RouteRegister.php
@@ -57,7 +57,7 @@ class RouteRegister
     public static function registerRoutes(Router $router): void
     {
         foreach (self::$tasks as $className => $task) {
-            $name    = $task['name'] ?? '';
+            $name    = $task['name'] ? $task['name'] : $className;
             $mapping = $task['mapping'] ?? [];
 
             if (empty($name) || empty($mapping)) {

--- a/src/task/src/Router/RouteRegister.php
+++ b/src/task/src/Router/RouteRegister.php
@@ -1,8 +1,6 @@
 <?php declare(strict_types=1);
 
-
 namespace Swoft\Task\Router;
-
 
 class RouteRegister
 {
@@ -57,15 +55,15 @@ class RouteRegister
     public static function registerRoutes(Router $router): void
     {
         foreach (self::$tasks as $className => $task) {
-            $name    = $task['name'] ? $task['name'] : $className;
             $mapping = $task['mapping'] ?? [];
 
-            if (empty($name) || empty($mapping)) {
+            if (!$mapping) {
                 continue;
             }
 
+            $name = $task['name'] ?: $className;
+            
             foreach ($mapping as $methodName => $map) {
-
                 $mappingName = $map['name'] ?? '';
                 if (empty($mappingName)) {
                     continue;


### PR DESCRIPTION
Fix '\Swoft\Task\Annotation\Mapping\Task' annotation 'name' field does not fill out, start error reporting
