### PR TITLE
Local environment over server environment

### DIFF
--- a/src/framework/src/Processor/EnvProcessor.php
+++ b/src/framework/src/Processor/EnvProcessor.php
@@ -47,7 +47,7 @@ class EnvProcessor extends Processor
             new PutenvAdapter,
             new ServerConstAdapter
         ]);
-        Dotenv::create($path, $name, $factory)->load();
+        Dotenv::create($path, $name, $factory)->overload();
 
         CLog::info('Env file(%s) is loaded', $envFile);
 


### PR DESCRIPTION
Without the overwrite mode, the configuration in the local `.env` file cannot overwrite the server configuration, and cannot be customized according to the project and development environment.