### PR TITLE
fix:Swoole\Http\Response::header(): http context is unavailable

### DIFF
--- a/src/http-server/src/HttpDispatcher.php
+++ b/src/http-server/src/HttpDispatcher.php
@@ -133,13 +133,13 @@ class HttpDispatcher extends AbstractDispatcher
      */
     private function afterRequest(Response $response): void
     {
-        $response->send();
-
-        // Defer
-        Swoft::trigger(SwoftEvent::COROUTINE_DEFER);
-
-        // Destroy
-        Swoft::trigger(SwoftEvent::COROUTINE_COMPLETE);
+//        $response->send();
+//
+//        // Defer
+//        Swoft::trigger(SwoftEvent::COROUTINE_DEFER);
+//
+//        // Destroy
+//        Swoft::trigger(SwoftEvent::COROUTINE_COMPLETE);
     }
 
     /**


### PR DESCRIPTION
This is a bug in `HttpDispatcher::dispatch()`:
```php
       // Trigger after request
        Swoft::trigger(HttpServerEvent::AFTER_REQUEST, null, $response);

        // After request
        $this->afterRequest($response);
```
what `afterRequest` did `AFTER_REQUEST` event already did, especially `$response->send()`.
so, it will have follow error:
```shell
swoft-srv | Fatal error: Uncaught ErrorException: Swoole\Http\Response::header(): http context is unavailable (maybe it has been ended or detached) in /var/www/swoft/vendor/swoft/http-message/src/Response.php:209
swoft-srv | Stack trace:
swoft-srv | #0 [internal function]: Swoft\Error\DefaultErrorDispatcher->handleError(2, 'Swoole\\Http\\Res...', '/var/www/swoft/...', 209, Array)
swoft-srv | #1 /var/www/swoft/vendor/swoft/http-message/src/Response.php(209): Swoole\Http\Response->header('content-type', 'application/jso...', false)
swoft-srv | #2 /var/www/swoft/vendor/swoft/http-message/src/Response.php(189): Swoft\Http\Message\Response->quickSend(Object(Swoft\Http\Message\Response))
swoft-srv | #3 /var/www/swoft/vendor/swoft/http-server/src/HttpDispatcher.php(137): Swoft\Http\Message\Response->send()
swoft-srv | #4 /var/www/swoft/vendor/swoft/http-server/src/HttpDispatcher.php(96): Swoft\Http\Server\HttpDispatcher->afterRequest(Object(Swoft\Http\Message\Response))
swoft-srv | #5 /var/www/swoft/vendor/swoft/http-server/src/Swoole/RequestListener.php(42): Swoft\Http\Server\HttpDispatcher->dispatch(Object(Swoft\Http\Mes in /var/www/swoft/vendor/swoft/http-message/src/Response.php on line 209
```