### PR TITLE
Null values do not need to respond

### DIFF
--- a/src/websocket-server/src/Swoole/MessageListener.php
+++ b/src/websocket-server/src/Swoole/MessageListener.php
@@ -101,7 +101,9 @@ class MessageListener implements MessageInterface
             // Do error dispatching
             $response = $errDispatcher->messageError($e, $frame, $response);
             // Do send response
-            $response->send();
+            if(!$response->isEmpty()){
+                $response->send();
+            }
         } finally {
             // Defer event
             Swoft::trigger(SwoftEvent::COROUTINE_DEFER);


### PR DESCRIPTION
No response is required for functions with `void` return type

### What does this PR do?

The controller returns `void` and the console will warn `[WARNING] cannot send empty response to websocket client`, which is unnecessary