### PR TITLE
No reconnection is made when rpc client receive data has timed out

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
     "ext-pdo": "*",
     "ext-json": "*",
     "ext-mbstring": "*",
+    "ext-sockets": "*",
     "doctrine/annotations": "^1.6",
     "php-di/phpdoc-reader": "^2.0",
     "psr/container": "^1.0",

--- a/src/rpc-client/src/Concern/ServiceTrait.php
+++ b/src/rpc-client/src/Concern/ServiceTrait.php
@@ -49,8 +49,7 @@ trait ServiceTrait
 
         $protocol = Protocol::new($version, $interfaceClass, $methodName, $params, $ext);
         $data = $packet->encode($protocol);
-        //$message = sprintf('Rpc call failed.interface=%s method=%s pool=%s version=%s', $interfaceClass, $methodName,
-        //    $poolName, $version);
+
         $message = 'Rpc call failed.code=%d message=%s ' . sprintf('interface=%s method=%s pool=%s version=%s',
                 $interfaceClass, $methodName, $poolName, $version);
 
@@ -95,7 +94,7 @@ trait ServiceTrait
 
         if (!$connection->send($data)) {
             if ($reconnect) {
-                $message = sprintf($message, $connection->errCode(), $connection->errMsg());
+                $message = sprintf($message, $connection->getErrCode(), $connection->getErrMsg());
                 $connection->release();
                 throw new RpcClientException($message);
             }
@@ -106,8 +105,8 @@ trait ServiceTrait
         $result = $connection->recv();
         if ($result === false || empty($result)) {
             //Reconnected or receive date timeout
-            if ($reconnect || $connection->errCode() === SOCKET_ETIMEDOUT) {
-                $message = sprintf($message, $connection->errCode(), $connection->errMsg());
+            if ($reconnect || $connection->getErrCode() === SOCKET_ETIMEDOUT) {
+                $message = sprintf($message, $connection->getErrCode(), $connection->getErrMsg());
                 $connection->release();
                 throw new RpcClientException($message);
             }

--- a/src/rpc-client/src/Concern/ServiceTrait.php
+++ b/src/rpc-client/src/Concern/ServiceTrait.php
@@ -23,7 +23,7 @@ trait ServiceTrait
     /**
      * @param string $interfaceClass
      * @param string $methodName
-     * @param array  $params
+     * @param array $params
      *
      * @return mixed
      * @throws ConnectionPoolException
@@ -34,7 +34,7 @@ trait ServiceTrait
     protected function __proxyCall(string $interfaceClass, string $methodName, array $params)
     {
         $poolName = ReferenceRegister::getPool(__CLASS__);
-        $version  = ReferenceRegister::getVersion(__CLASS__);
+        $version = ReferenceRegister::getVersion(__CLASS__);
 
         /* @var Pool $pool */
         $pool = BeanFactory::getBean($poolName);
@@ -48,17 +48,19 @@ trait ServiceTrait
         $ext = $connection->getClient()->getExtender()->getExt();
 
         $protocol = Protocol::new($version, $interfaceClass, $methodName, $params, $ext);
-        $data     = $packet->encode($protocol);
-        $message  = sprintf('Rpc call failed.interface=%s method=%s pool=%s version=%s', $interfaceClass, $methodName,
-            $poolName, $version);
+        $data = $packet->encode($protocol);
+        //$message = sprintf('Rpc call failed.interface=%s method=%s pool=%s version=%s', $interfaceClass, $methodName,
+        //    $poolName, $version);
+        $message = 'Rpc call failed.code=%d message=%s ' . sprintf('interface=%s method=%s pool=%s version=%s',
+                $interfaceClass, $methodName, $poolName, $version);
 
         $result = $this->sendAndRecv($connection, $data, $message);
         $connection->release();
 
         $response = $packet->decodeResponse($result);
         if ($response->getError() !== null) {
-            $code      = $response->getError()->getCode();
-            $message   = $response->getError()->getMessage();
+            $code = $response->getError()->getCode();
+            $message = $response->getError()->getMessage();
             $errorData = $response->getError()->getData();
 
             // Record rpc error message
@@ -77,9 +79,9 @@ trait ServiceTrait
 
     /**
      * @param Connection $connection
-     * @param string     $data
-     * @param string     $message
-     * @param bool       $reconnect
+     * @param string $data
+     * @param string $message
+     * @param bool $reconnect
      *
      * @return string
      * @throws RpcClientException
@@ -93,6 +95,8 @@ trait ServiceTrait
 
         if (!$connection->send($data)) {
             if ($reconnect) {
+                $message = sprintf($message, $connection->errCode(), $connection->errMsg());
+                $connection->release();
                 throw new RpcClientException($message);
             }
 
@@ -101,7 +105,10 @@ trait ServiceTrait
 
         $result = $connection->recv();
         if ($result === false || empty($result)) {
-            if ($reconnect) {
+            //Reconnected or receive date timeout
+            if ($reconnect || $connection->errCode() === SOCKET_ETIMEDOUT) {
+                $message = sprintf($message, $connection->errCode(), $connection->errMsg());
+                $connection->release();
                 throw new RpcClientException($message);
             }
 

--- a/src/rpc-client/src/Connection.php
+++ b/src/rpc-client/src/Connection.php
@@ -41,7 +41,7 @@ class Connection extends AbstractConnection implements ConnectionInterface
 
     /**
      * @param \Swoft\Rpc\Client\Client $client
-     * @param Pool                     $pool
+     * @param Pool $pool
      *
      * @return Connection
      */
@@ -50,7 +50,7 @@ class Connection extends AbstractConnection implements ConnectionInterface
         $instance = self::__instance();
 
         $instance->client = $client;
-        $instance->pool   = $pool;
+        $instance->pool = $pool;
 
         $instance->lastTime = time();
 
@@ -133,6 +133,23 @@ class Connection extends AbstractConnection implements ConnectionInterface
         return $this->connection->recv();
     }
 
+
+    /**
+     * @return int
+     */
+    public function errCode()
+    {
+        return $this->connection->errCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function errMsg()
+    {
+        return $this->connection->errMsg;
+    }
+
     /**
      * @return array
      * @throws RpcClientException
@@ -153,7 +170,7 @@ class Connection extends AbstractConnection implements ConnectionInterface
             throw new RpcClientException(sprintf('Provider(%s) return format is error!', JsonHelper::encode($list)));
         }
 
-        $randKey  = array_rand($list, 1);
+        $randKey = array_rand($list, 1);
         $hostPort = explode(':', $list[$randKey]);
 
         if (count($hostPort) < 2) {

--- a/src/rpc-client/src/Connection.php
+++ b/src/rpc-client/src/Connection.php
@@ -137,7 +137,7 @@ class Connection extends AbstractConnection implements ConnectionInterface
     /**
      * @return int
      */
-    public function errCode()
+    public function getErrCode()
     {
         return $this->connection->errCode;
     }
@@ -145,7 +145,7 @@ class Connection extends AbstractConnection implements ConnectionInterface
     /**
      * @return string
      */
-    public function errMsg()
+    public function getErrMsg()
     {
         return $this->connection->errMsg;
     }


### PR DESCRIPTION
如果在rpc client设置了read_timeout为一个非-1的值，当rpc server运行的时间超过read_timeout的时候，rpc client的sendAndRecv方法就会执行两次，结果就会导致服务端被正常调用两次！
因此当客户端错误为timeout的时候不能执行reconnect，而是应该立刻抛出异常。