### PR TITLE
optimize # support customer defined getter for Entify, reference issu…

### DIFF
--- a/src/db/src/Concern/HasAttributes.php
+++ b/src/db/src/Concern/HasAttributes.php
@@ -78,7 +78,7 @@ trait HasAttributes
      */
     public function getArrayableAttributes(): array
     {
-        return array_merge($this->modelAttributes, $this->getModelAttributes());
+        return array_merge($this->getModelAttributes(), $this->modelAttributes);
     }
 
     /**
@@ -186,7 +186,7 @@ trait HasAttributes
      * Get the value of an attribute using its mutator.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return mixed
      */
@@ -242,7 +242,7 @@ trait HasAttributes
      * Set the value of an attribute using its mutator.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return mixed
      */
@@ -258,7 +258,7 @@ trait HasAttributes
      * Set a given JSON attribute on the model.
      *
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return $this
      */
@@ -278,7 +278,7 @@ trait HasAttributes
      *
      * @param string $path
      * @param string $key
-     * @param mixed  $value
+     * @param mixed $value
      *
      * @return array
      */
@@ -321,7 +321,7 @@ trait HasAttributes
      * Decode the given JSON back into an array or object.
      *
      * @param string $value
-     * @param bool   $asObject
+     * @param bool $asObject
      *
      * @return mixed
      */
@@ -390,7 +390,7 @@ trait HasAttributes
      * Set the array of model attributes. No checking is done.
      *
      * @param array $attributes
-     * @param bool  $sync
+     * @param bool $sync
      *
      * @return $this
      * @throws DbException
@@ -417,7 +417,7 @@ trait HasAttributes
      * Get safe model attributes
      *
      * @param array $attributes
-     * @param bool  $encode
+     * @param bool $encode
      *
      * @return array
      */
@@ -478,7 +478,7 @@ trait HasAttributes
      * Get the model's original attribute values.
      *
      * @param string|null $key
-     * @param mixed       $default
+     * @param mixed $default
      *
      * @return mixed|array
      */
@@ -606,7 +606,7 @@ trait HasAttributes
     /**
      * Determine if the given attributes were changed.
      *
-     * @param array             $changes
+     * @param array $changes
      * @param array|string|null $attributes
      *
      * @return bool
@@ -660,7 +660,7 @@ trait HasAttributes
      * Determine if the new and old values for a given key are equivalent.
      *
      * @param string $key
-     * @param mixed  $current
+     * @param mixed $current
      *
      * @return bool
      */
@@ -670,7 +670,7 @@ trait HasAttributes
             return false;
         }
 
-        $original = $this->getModelOriginal($key);
+        $original = $this->getModelAttribute($key);
 
         if ($current === $original) {
             return true;


### PR DESCRIPTION
…es # 1322

### What does this PR do?

支持用户自定义模型getter


### Motivation

业务数据库设计中，经常使用英文逗号分隔的字段，或json_encode过的字段，通常希望取出来的时候是数组，方便直接返回给前端。但目前使用entity:create的默认是string类型，如果修改 实体的getter强制 explode(',' $val)并返回数组时，读取数据没有问题，但插入、更新操作的时候报错 array to string...，参考 issue:1322

