### PR TITLE
fix RPC连接池复用过程中拿到上一个请求的结果问题

### DIFF
--- a/src/rpc-client/src/Concern/ServiceTrait.php
+++ b/src/rpc-client/src/Concern/ServiceTrait.php
@@ -130,9 +130,11 @@ trait ServiceTrait
         if ($result === false || empty($result)) {
             // Has been reconnected OR receive date timeout
             if ($reconnect || $connection->getErrCode() === SOCKET_ETIMEDOUT) {
-                if($connection->getErrCode() === SOCKET_ETIMEDOUT) {
+                // fix: reusing use the connection will read old response data.
+                if ($connection->getErrCode() === SOCKET_ETIMEDOUT) {
                     $connection->reconnect();
                 }
+
                 $message = sprintf($message, $connection->getErrCode(), $connection->getErrMsg());
                 throw new RpcClientException($message);
             }

--- a/src/rpc-client/src/Concern/ServiceTrait.php
+++ b/src/rpc-client/src/Concern/ServiceTrait.php
@@ -130,6 +130,9 @@ trait ServiceTrait
         if ($result === false || empty($result)) {
             // Has been reconnected OR receive date timeout
             if ($reconnect || $connection->getErrCode() === SOCKET_ETIMEDOUT) {
+                if($connection->getErrCode() === SOCKET_ETIMEDOUT) {
+                    $connection->reconnect();
+                }
                 $message = sprintf($message, $connection->getErrCode(), $connection->getErrMsg());
                 throw new RpcClientException($message);
             }

--- a/src/rpc-client/test/testing/Lib/RpcReadOldCallInterface.php
+++ b/src/rpc-client/test/testing/Lib/RpcReadOldCallInterface.php
@@ -1,0 +1,17 @@
+<?php declare(strict_types=1);
+
+namespace SwoftTest\Rpc\Client\Testing\Lib;
+
+
+interface RpcReadOldCallInterface
+{
+    /**
+     * @return int
+     */
+    public function getIntResult();
+
+    /**
+     * @return string
+     */
+    public function getStringResult();
+}

--- a/src/rpc-client/test/testing/Lib/RpcReadOldCallInterface.php
+++ b/src/rpc-client/test/testing/Lib/RpcReadOldCallInterface.php
@@ -2,7 +2,9 @@
 
 namespace SwoftTest\Rpc\Client\Testing\Lib;
 
-
+/**
+ * interface RpcReadOldCallInterface
+ */
 interface RpcReadOldCallInterface
 {
     /**

--- a/src/rpc-client/test/testing/RpcReadOldCallService.php
+++ b/src/rpc-client/test/testing/RpcReadOldCallService.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace SwoftTest\Rpc\Client\Testing;
+
+use Swoole\Coroutine;
+use Swoft\Rpc\Protocol;
+use Swoft\Rpc\Server\Annotation\Mapping\Service;
+use SwoftTest\Rpc\Client\Testing\Lib\RpcReadOldCallInterface;
+
+/**
+ * Class RpcReadOldCallService
+ *
+ * @since 2.0
+ *
+ * @Service(version=Protocol::DEFAULT_VERSION)
+ */
+class RpcReadOldCallService implements RpcReadOldCallInterface
+{
+
+    /**
+     * @return int
+     */
+    public function getIntResult()
+    {
+        return 1;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStringResult()
+    {
+        Coroutine::sleep(1);
+        return 'string';
+    }
+}

--- a/src/rpc-client/test/unit/RpcReadOldCallTest.php
+++ b/src/rpc-client/test/unit/RpcReadOldCallTest.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace SwoftTest\Rpc\Client\Unit;
+
+use Swoft\Rpc\Packet;
+use Swoole\Coroutine;
+use Swoft\Rpc\Protocol;
+use Swoft\Rpc\Client\Pool;
+use Swoft\Context\Context;
+use Swoft\Rpc\Client\Proxy;
+use Swoft\Bean\BeanFactory;
+use Swoole\Coroutine\Server;
+use Swoft\Rpc\Client\Client;
+use SwoftTest\Testing\TestContext;
+use Swoole\Coroutine\Server\Connection;
+use Swoft\Rpc\Client\ReferenceRegister;
+use SwoftTest\Rpc\Server\Testing\MockRpcServer;
+use Swoft\Rpc\Client\Annotation\Mapping\Reference;
+use Swoft\Rpc\Client\Exception\RpcClientException;
+use SwoftTest\Rpc\Client\Testing\Lib\RpcReadOldCallInterface;
+
+class RpcReadOldCallTest extends TestCase
+{
+    /**
+     * @var MockRpcServer
+     */
+    private static $mockRpcServer;
+
+    /**
+     * @Reference("user.pool")
+     * @var RpcReadOldCallInterface
+     */
+    private static $rpcReadOldCallService;
+
+    /**
+     * @var Server
+     */
+    private static $server;
+
+    /**
+     * @var Pool
+     */
+    private static $rpcClientPool;
+
+    /**
+     * 初始化服务
+     */
+    public static function setUpBeforeClass(): void
+    {
+
+        // 创建RPC客户端
+        $rpcClientDefinition = [
+            'class'   => Client::class,
+            'host'    => '127.0.0.1',
+            'port'    => 18307,
+            'setting' => [
+                'timeout'         => 1,
+                'connect_timeout' => 1,
+                'write_timeout'   => 1,
+                'read_timeout'    => 1,
+            ],
+            'packet'  => bean('rpcClientPacket')
+        ];
+
+        // 创建RPC客户端连接池
+        $rpcClientPoolDefinition = [
+            'class'  => Pool::class,
+            'client' => BeanFactory::createBean('rpc.client', $rpcClientDefinition),
+            'minActive' => 1,
+            'maxActive' => 1,
+        ];
+        self::$rpcClientPool = BeanFactory::createBean('rpc.client.pool', $rpcClientPoolDefinition);
+
+        // 创建模拟服务对象
+        self::$mockRpcServer = new MockRpcServer();
+
+        // 创建代理请求服务
+        Coroutine::create(function (){
+            self::$server = $server = new Server('127.0.0.1', 18307, false, true);
+            $server->set([
+                'open_eof_check' => true,
+                'open_eof_split' => true,
+                'package_eof'    => "\r\n\r\n",
+            ]);
+            /* @var Packet $packet */
+            $packet = bean('rpcServerPacket');
+            $server->handle(function (Connection $conn) use($packet){
+                while (true) {
+                    $data = $conn->recv();
+                    if ($data === '' || $data === false) {
+                        $conn->close();
+                        break;
+                    }
+                    $params = json_decode($data, true);
+                    if(isset($params['method']) && isset($params['ext'])) {
+                        $method = explode('::', $params['method']);
+                        $response = self::$mockRpcServer->call($method[1], $method[2], $params['params'], $params['ext'], $method[0]);
+                        $conn->send($packet->encodeResponse($response->getData()));
+                    }
+                    Coroutine::sleep(0.01);
+                }
+            });
+
+            $server->start();
+        });
+
+        // 创建客户端代理对象
+        $className  = Proxy::newClassName(RpcReadOldCallInterface::class, 'user.pool_1.0');
+        ReferenceRegister::register($className, 'rpc.client.pool', Protocol::DEFAULT_VERSION);
+        self::$rpcReadOldCallService = new $className();
+
+        // 初始化上下文
+        $context = TestContext::new();
+        Context::set($context);
+    }
+
+    /**
+     * 模拟读取数据超时
+     */
+    public function testA(): void
+    {
+        $this->expectException(RpcClientException::class);
+        self::$rpcReadOldCallService->getStringResult();
+    }
+
+    /**
+     * 复现读取到上一个请求的数据
+     */
+    public function testB(): void
+    {
+        $result = self::$rpcReadOldCallService->getIntResult();
+        $this->assertIsInt($result);
+        $this->assertEquals(1, $result);
+    }
+
+    /**
+     * 关闭服务和连接池
+     */
+    public static function tearDownAfterClass(): void
+    {
+        self::$rpcClientPool->close();
+        self::$server->shutdown();
+    }
+}


### PR DESCRIPTION
### What does this PR do?

修复RPC连接池复用过程中拿到上一个请求的结果问题
例如请求A发送后读读超时抛异常连接回池，这时候B请求发出后复用了A请求的连接，直接拿到了A请求的结果


#### Does this fix any issues or need any specific reviewers?

Fixes: swoft-cloud/swoft#1371
Reviewers: @inhere 

### Motivation

线上BUG！！！


### More

- [x] Added/updated tests
- [ ] Added/updated documentation [new][doc2] or [old][doc1]

