### PR TITLE
fix: swoft-cloud/swoft/issues/1472

### DIFF
--- a/src/rpc-client/src/Concern/ServiceTrait.php
+++ b/src/rpc-client/src/Concern/ServiceTrait.php
@@ -93,9 +93,9 @@ trait ServiceTrait
 
             $result = $response->getResult();
         } catch (Throwable $e) {
+            $connection->reconnect();
             throw $e;
         } finally { // NOTICE: always release resource
-            $connection->reconnect();
             $connection->release();
         }
 

--- a/src/rpc-client/src/Concern/ServiceTrait.php
+++ b/src/rpc-client/src/Concern/ServiceTrait.php
@@ -95,6 +95,7 @@ trait ServiceTrait
         } catch (Throwable $e) {
             throw $e;
         } finally { // NOTICE: always release resource
+            $connection->reconnect();
             $connection->release();
         }
 


### PR DESCRIPTION
### What does this PR do?
修复 当rpc服务端处理超时而导致客户端 timeout 时，客户端中使用同一 connection 的后续请求会得到上一次请求的处理结果
[类似这种](https://github.com/swoft-cloud/swoft/issues/1472)
#### Does this fix any issues or need any specific reviewers?

Fixes: swoft-cloud/swoft#
Reviewers: @
